### PR TITLE
Add Flask endpoint for latest MQTT post

### DIFF
--- a/MeasurePi.py
+++ b/MeasurePi.py
@@ -391,6 +391,20 @@ def serial_command():
     return jsonify({"status": "sent", "command": cmd})
 
 
+@app.route("/api/latest_mqtt_post")
+def latest_mqtt_post():
+    with _data_lock:
+        if not raw_mqtt_history:
+            return jsonify({"error": "No MQTT messages available"}), 404
+        latest_post_str = raw_mqtt_history[-1]
+    try:
+        latest_post_json = json.loads(latest_post_str)
+        return jsonify(latest_post_json)
+    except json.JSONDecodeError:
+        # This case should ideally not happen if raw_mqtt_history only stores valid JSON strings
+        return jsonify({"error": "Failed to parse stored MQTT message"}), 500
+
+
 if __name__ == "__main__":
     try:
         _init_hardware()


### PR DESCRIPTION
Introduces a new endpoint /api/latest_mqtt_post that returns the most recent JSON message from the raw_mqtt_history.

Includes:
- Retrieval of the latest message.
- Thread-safe access to raw_mqtt_history using _data_lock.
- Error handling for empty history (404).
- Error handling for JSON parsing issues (500).
- Ensures the response is a JSON object, not a stringified JSON.