### PR TITLE
Clarify HX711 payload semantics and wiring

### DIFF
--- a/MeasurePi.py
+++ b/MeasurePi.py
@@ -144,8 +144,13 @@ def _on_message(client, userdata, msg):
             new_measurements["weight_gross"] = _safe_float(data.get("weight_gross"))
             new_measurements["tare_g"] = _safe_int(data.get("tare_g"))
 
-            if new_measurements.get("weight") is None and new_measurements.get("weight_net") is not None:
-                new_measurements["weight"] = new_measurements["weight_net"]
+            if new_measurements.get("weight") is None:
+                gross_val = new_measurements.get("weight_gross")
+                net_val = new_measurements.get("weight_net")
+                if gross_val is not None:
+                    new_measurements["weight"] = gross_val
+                elif net_val is not None:
+                    new_measurements["weight"] = net_val
 
             with _data_lock:
                 current_measurement.clear()

--- a/dws1.ino
+++ b/dws1.ino
@@ -14,6 +14,8 @@
  *   CAPTURE button -> D12 to GND (INPUT_PULLUP)
  *   TARE button    -> D9  to GND (INPUT_PULLUP)
  *   LCD (I²C PCF8574) on same I²C bus as TCA (auto-addr)
+ *   HX711 DOUT     -> D2  (digital)
+ *   HX711 SCK      -> D3  (digital)
  *
  * Revision: V-16/10/25 05:44 (Add_LCD_Log_20x4)
  *************************************************************/
@@ -511,11 +513,13 @@ static void publishJson_any(float h,float w,float l, bool haveScale, float net_k
     strcpy(netTxt, "null"); strcpy(grossTxt, "null"); strcpy(tareTxt, "null");
   }
 
+  const char* weightTxt = grossTxt;
+
   char payload[256];
   snprintf(payload,sizeof(payload),
     "{\"height\":%s,\"width\":%s,\"length\":%s,"
     "\"weight\":%s,\"weight_net\":%s,\"weight_gross\":%s,\"tare_g\":%s}",
-    hTxt,wTxt,lTxt, netTxt,netTxt,grossTxt,tareTxt);
+    hTxt,wTxt,lTxt, weightTxt,netTxt,grossTxt,tareTxt);
 
   mqttClient.publish(TOPIC_DATA, payload, false);
   logLine("[MQTT] Publish data OK");


### PR DESCRIPTION
## Summary
- document the HX711 signal wiring in the UNO sketch header comment
- publish gross weight in the weight field of the MQTT payload to avoid duplicating the net value
- update the MeasurePi bridge to prefer the gross reading when backfilling the weight field

## Testing
- python -m compileall MeasurePi.py

------
https://chatgpt.com/codex/tasks/task_e_68f32c5042a08326a6904ef2623ea794