### PR TITLE
Restore net weight publishing for MQTT weight field

### DIFF
--- a/dws1.ino
+++ b/dws1.ino
@@ -513,7 +513,7 @@ static void publishJson_any(float h,float w,float l, bool haveScale, float net_k
     strcpy(netTxt, "null"); strcpy(grossTxt, "null"); strcpy(tareTxt, "null");
   }
 
-  const char* weightTxt = grossTxt;
+  const char* weightTxt = netTxt;
 
   char payload[256];
   snprintf(payload,sizeof(payload),


### PR DESCRIPTION
## Summary
- restore the MQTT `weight` field to use the net measurement so the UI still shows tare-adjusted values

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f32f87bad88326bcc349ed29cb0e13