### PR TITLE
Prompt for manual weight when scale offline

### DIFF
--- a/MeasurePi.py
+++ b/MeasurePi.py
@@ -58,12 +58,19 @@ current_measurement = {}
 measurement_history = []
 raw_mqtt_history = []
 measure_log_history = []
-_data_lock = threading.Lock()  
-_last_lcd_text = ""       
+_data_lock = threading.Lock()
+_last_lcd_text = ""
 
 rounding_settings = DEFAULT_ROUNDING_SETTINGS.copy()
 
 mqtt_client = mqtt.Client(client_id=f"measure_pi_client_{os.getpid()}", protocol=mqtt.MQTTv311)
+
+# Track whether the external scale is available and if manual weight input
+# is pending. These values are updated as MQTT payloads arrive and when
+# manual weight overrides are submitted via the API.
+scale_present_flag = None  # None = unknown, True = scale detected, False = no scale
+awaiting_manual_weight = False
+pending_manual_weight_value = None
 
 
 # ─── MQTT Callbacks ──────────────────────────────────────────────────────────
@@ -119,7 +126,7 @@ def _safe_int(value):
 
 
 def _on_message(client, userdata, msg):
-    global _last_lcd_text
+    global _last_lcd_text, scale_present_flag, pending_manual_weight_value, awaiting_manual_weight
     # print(f"[MQTT] Received message on topic '{msg.topic}': {msg.payload.decode()}")
 
     if msg.topic == MQTT_TOPIC_SUB:
@@ -151,6 +158,31 @@ def _on_message(client, userdata, msg):
                     new_measurements["weight"] = gross_val
                 elif net_val is not None:
                     new_measurements["weight"] = net_val
+
+            have_scale = any(
+                new_measurements.get(key) is not None
+                for key in ("weight", "weight_net", "weight_gross", "tare_g")
+            )
+            new_measurements["scale_present"] = have_scale
+
+            if not have_scale:
+                new_measurements["manual_weight_required"] = True
+                manual_override = pending_manual_weight_value
+                if isinstance(manual_override, (int, float)):
+                    manual_value = float(manual_override)
+                    new_measurements["weight"] = manual_value
+                    new_measurements["weight_net"] = manual_value
+                    new_measurements["weight_gross"] = manual_value
+                    new_measurements["manual_weight"] = True
+                    new_measurements["manual_weight_timestamp"] = time.time()
+                    pending_manual_weight_value = None
+                    awaiting_manual_weight = False
+            else:
+                new_measurements["manual_weight_required"] = False
+                pending_manual_weight_value = None
+                awaiting_manual_weight = False
+
+            scale_present_flag = have_scale
 
             with _data_lock:
                 current_measurement.clear()
@@ -315,6 +347,10 @@ def json_data_route():
         tare_value = current_data_copy.get("tare_g")
         current_rounded["tare_g"] = int(tare_value) if isinstance(tare_value, (int, float)) else None
 
+    for meta_key in ["scale_present", "manual_weight_required", "manual_weight", "manual_weight_timestamp"]:
+        if meta_key in current_data_copy:
+            current_rounded[meta_key] = current_data_copy[meta_key]
+
     return jsonify({"current": current_rounded, "history": history_to_send})
 
 @app.route("/api/raw")
@@ -406,13 +442,92 @@ def command_api_route():
 
 @app.route("/api/capture", methods=["POST"])
 def capture_api_route():
+    global awaiting_manual_weight
+
+    with _data_lock:
+        current_scale_state = scale_present_flag
+        if current_scale_state is False:
+            awaiting_manual_weight = True
+        else:
+            awaiting_manual_weight = False
+
     if mqtt_client.is_connected():
         mqtt_client.publish(MQTT_CAPTURE_TOPIC, "CAP")
         print(f"[API-CAPTURE] Capture command published to MQTT topic '{MQTT_CAPTURE_TOPIC}'.")
-        return jsonify({"status": "sent", "message": "Capture requested."})
+
+        response_payload = {
+            "status": "sent",
+            "message": "Capture requested.",
+            "scale_present": current_scale_state,
+            "manual_weight_required": current_scale_state is False,
+        }
+
+        if current_scale_state is False:
+            response_payload["message"] = "Capture requested. Scale offline – please enter weight manually."
+
+        return jsonify(response_payload)
     else:
         print("[API-CAPTURE] Failed to publish capture command: MQTT client not connected.")
         return jsonify({"status": "error", "message": "MQTT client not connected"}), 503
+
+
+@app.route("/api/manual_weight", methods=["POST"])
+def manual_weight_api_route():
+    global pending_manual_weight_value, awaiting_manual_weight, scale_present_flag
+
+    if not request.is_json:
+        return jsonify({"error": "Request must be JSON"}), 400
+
+    payload = request.get_json()
+    manual_weight_value = _safe_float(payload.get("weight"))
+
+    if manual_weight_value is None:
+        return jsonify({"error": "A numeric 'weight' value (kg) is required"}), 400
+
+    manual_weight_value = float(manual_weight_value)
+    manual_weight_value = round(manual_weight_value, 3)
+    timestamp = time.time()
+    applied_immediately = False
+
+    with _data_lock:
+        pending_manual_weight_value = manual_weight_value
+        awaiting_manual_weight = False
+
+        if current_measurement:
+            current_weight = current_measurement.get("weight")
+            if not isinstance(current_weight, (int, float)):
+                current_measurement["weight"] = manual_weight_value
+                current_measurement["weight_net"] = manual_weight_value
+                current_measurement["weight_gross"] = manual_weight_value
+                current_measurement["manual_weight"] = True
+                current_measurement["manual_weight_timestamp"] = timestamp
+                current_measurement["manual_weight_required"] = False
+                current_measurement["scale_present"] = False
+                applied_immediately = True
+
+        if measurement_history:
+            last_entry = measurement_history[-1]
+            last_weight = last_entry.get("weight") if isinstance(last_entry, dict) else None
+            if not isinstance(last_weight, (int, float)):
+                last_entry["weight"] = manual_weight_value
+                last_entry["weight_net"] = manual_weight_value
+                last_entry["weight_gross"] = manual_weight_value
+                last_entry["manual_weight"] = True
+                last_entry["manual_weight_timestamp"] = timestamp
+                last_entry["manual_weight_required"] = False
+                last_entry["scale_present"] = False
+                applied_immediately = True
+
+        if applied_immediately:
+            pending_manual_weight_value = None
+            scale_present_flag = False
+
+    print(f"[MANUAL-WEIGHT] {'Applied' if applied_immediately else 'Stored'} manual weight {manual_weight_value:.3f}kg")
+    return jsonify({
+        "status": "accepted",
+        "applied": applied_immediately,
+        "weight": manual_weight_value,
+    })
 
 # ─── Main Application Logic ───────────────────────────────────────────────────
 def run_application():

--- a/dws1.js
+++ b/dws1.js
@@ -23,6 +23,94 @@
   const MQTT_PAYLOAD = "CAPTURE";
   const MQTT_JS_URL = "https://unpkg.com/mqtt/dist/mqtt.min.js";
 
+  const jsonEndpointUrl = new URL(JSON_URL, window.location.href);
+
+  function resolveApiUrl(path) {
+    const base = new URL(jsonEndpointUrl.href);
+    const cleanedBaseSegments = base.pathname.split("/").filter(Boolean);
+    if (cleanedBaseSegments.length && cleanedBaseSegments[cleanedBaseSegments.length - 1].toLowerCase() === "json") {
+      cleanedBaseSegments.pop();
+    }
+    const requestedSegments = String(path || "").split("/").filter(Boolean);
+    const combined = cleanedBaseSegments.concat(requestedSegments);
+    base.pathname = combined.length ? `/${combined.join("/")}` : "/";
+    return base.toString();
+  }
+
+  const MANUAL_WEIGHT_URL = resolveApiUrl("api/manual_weight");
+
+  const promptForManualWeight = async (message = "Scale offline. Enter weight in kg:") => {
+    let lastValue = "";
+    while (true) {
+      const response = window.prompt(message, lastValue);
+      if (response === null) {
+        return null;
+      }
+
+      const parsed = Number.parseFloat(response);
+      if (!Number.isFinite(parsed) || parsed < 0) {
+        alert("Please enter a valid non-negative number for weight (kg).");
+        lastValue = response;
+        continue;
+      }
+
+      return Math.round(parsed * 1000) / 1000;
+    }
+  };
+
+  async function submitManualWeight(weightKg) {
+    const body = JSON.stringify({ weight: weightKg });
+    const response = await fetch(MANUAL_WEIGHT_URL, {
+      method: "POST",
+      mode: "cors",
+      headers: { "Content-Type": "application/json" },
+      body
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text().catch(() => "");
+      throw new Error(`Manual weight API error (${response.status}): ${errorText}`.trim());
+    }
+
+    return response.json().catch(() => ({ status: "accepted" }));
+  }
+
+  const needsManualWeight = (data) => {
+    if (!data || typeof data !== "object") return false;
+    if (data.manual_weight_required === true) return true;
+    if (data.scale_present === false) {
+      const w = Number.parseFloat(data.weight ?? data.weight_gross ?? data.weight_net);
+      if (!Number.isFinite(w)) return true;
+    }
+    const weightValue = Number.parseFloat(data.weight ?? data.weight_gross ?? data.weight_net);
+    return !Number.isFinite(weightValue);
+  };
+
+  async function ensureManualWeight(data) {
+    if (!needsManualWeight(data)) {
+      return data;
+    }
+
+    const manualWeight = await promptForManualWeight();
+    if (manualWeight === null) {
+      throw new Error("Manual weight entry cancelled by user");
+    }
+
+    try {
+      await submitManualWeight(manualWeight);
+    } catch (err) {
+      console.warn("[GSS][ManualWeight] Submission failed", err);
+    }
+
+    const normalized = Number.parseFloat(manualWeight.toFixed(3));
+    data.weight = normalized;
+    data.weight_net = normalized;
+    data.weight_gross = normalized;
+    data.manual_weight = true;
+    data.manual_weight_required = false;
+    return data;
+  }
+
   // ---------- UI creation ----------
   function createFixedFetchButton() {
     const id = "gss-fetch";
@@ -211,6 +299,14 @@
         alert("Invalid data received. Check your API response.");
         return;
       }
+
+      try {
+        await ensureManualWeight(data);
+      } catch (manualErr) {
+        console.warn("[GSS][ManualWeight] Cancelled or failed", manualErr);
+        alert("Manual weight entry is required to continue.");
+        return;
+      }
       autoFillNextAvailableRow(data);
     } catch (err) {
       console.error("[GSS][Fetch] Error:", err);
@@ -231,6 +327,13 @@
           if (resp.ok) {
             const data = await resp.json();
             if (isValidPayload(data)) {
+              try {
+                await ensureManualWeight(data);
+              } catch (manualErr) {
+                console.warn("[GSS][ManualWeight] Cancelled or failed", manualErr);
+                alert("Manual weight entry is required to continue.");
+                return;
+              }
               console.log(`[GSS][Measure] Got data after ${tries} poll(s):`, data);
               autoFillNextAvailableRow(data);
               return;

--- a/templates/index.html
+++ b/templates/index.html
@@ -432,6 +432,51 @@
     const captureFeedbackEl = document.getElementById("captureFeedback");
     const tareButtonEl = document.getElementById("tareButton");
     const tareFeedbackEl = document.getElementById("tareFeedback");
+    const manualWeightEndpoint = "/api/manual_weight";
+
+    const submitManualWeight = async (weightKg) => {
+      const response = await fetch(manualWeightEndpoint, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ weight: weightKg })
+      });
+
+      if (!response.ok) {
+        const errorText = await response.text().catch(() => "");
+        throw new Error(`Manual weight submission failed (${response.status}): ${errorText}`.trim());
+      }
+
+      return response.json().catch(() => ({ status: "accepted" }));
+    };
+
+    const promptForManualWeight = async (promptMessage = "Enter weight in kg:", defaultValue = "") => {
+      let inputValue = defaultValue;
+      while (true) {
+        const userInput = window.prompt(promptMessage, inputValue);
+        if (userInput === null) {
+          return null;
+        }
+
+        const parsed = Number.parseFloat(userInput);
+        if (!Number.isFinite(parsed) || parsed < 0) {
+          alert("Please enter a valid non-negative number (kg).");
+          inputValue = userInput;
+          continue;
+        }
+
+        return Math.round(parsed * 1000) / 1000;
+      }
+    };
+
+    const ensureManualWeightPresent = async () => {
+      const weightValue = await promptForManualWeight("Scale offline. Please enter the weight (kg):");
+      if (weightValue === null) {
+        throw new Error("Manual weight entry cancelled by user");
+      }
+
+      await submitManualWeight(weightValue);
+      return weightValue;
+    };
 
     const setLcdOverlayMessage = (message = "") => {
       if (!lcdOverlayEl) return;
@@ -615,6 +660,15 @@
       return `Wt:${num.toFixed(2)}kg`;
     };
 
+    const formatHistoryWeight = (entry) => {
+      if (!entry || typeof entry !== "object") return "--";
+      const rawWeight = entry.weight ?? entry.weight_gross ?? entry.weight_net;
+      const numeric = typeof rawWeight === "number" ? rawWeight : Number.parseFloat(rawWeight);
+      if (!Number.isFinite(numeric)) return "--";
+      const suffix = entry.manual_weight ? " (manual)" : "";
+      return `${numeric.toFixed(2)} kg${suffix}`;
+    };
+
     const renderLCD = (current, history) => {
       const latest = selectLatestMeasurement(current, history);
       if (!latest) {
@@ -649,7 +703,7 @@
               <td>${formatNumber(item.height)} cm</td>
               <td>${formatNumber(item.width)} cm</td>
               <td>${formatNumber(item.length)} cm</td>
-              <td>${item.weight !== undefined && item.weight !== null ? `${Number(item.weight).toFixed(2)} kg` : "--"}</td>
+              <td>${formatHistoryWeight(item)}</td>
             </tr>
           `;
         })
@@ -743,8 +797,24 @@
           }
 
           const data = await response.json().catch(() => ({}));
-          captureFeedbackEl.textContent = data.message || "Capture requested.";
+          const baseMessage = data.message || "Capture requested.";
+          captureFeedbackEl.textContent = baseMessage;
           captureFeedbackEl.classList.add("success");
+
+          if (data?.manual_weight_required) {
+            try {
+              const manualWeight = await ensureManualWeightPresent();
+              captureFeedbackEl.textContent = `${baseMessage} Manual weight ${manualWeight.toFixed(3)} kg recorded.`;
+              captureFeedbackEl.classList.remove("error");
+              captureFeedbackEl.classList.add("success");
+              refreshDashboard();
+            } catch (manualError) {
+              console.warn("Manual weight entry cancelled or failed", manualError);
+              captureFeedbackEl.textContent = `${baseMessage} Manual weight entry required.`;
+              captureFeedbackEl.classList.remove("success");
+              captureFeedbackEl.classList.add("error");
+            }
+          }
         } catch (error) {
           console.error("Capture trigger failed", error);
           captureFeedbackEl.textContent = "Unable to trigger capture.";


### PR DESCRIPTION
## Summary
- track scale availability on the server, persist manual weight overrides, and expose a new API to record them
- prompt dashboard users for manual weights when the scale is offline and display manual entries in history
- update the Tampermonkey helper to request manual weights and push them back to the MeasurePi service when needed

## Testing
- python -m py_compile MeasurePi.py

------
https://chatgpt.com/codex/tasks/task_e_6906c6ab83048326b7f79f3dd26aef26