### PR TITLE
Remove unused warning flag

### DIFF
--- a/ino.ino
+++ b/ino.ino
@@ -291,7 +291,6 @@ static void statusLedsUpdate() {
   bool tcaOk    = g_tcaPresent;
   bool tfOk     = (g_tfInit1Ok && g_tfInit2Ok && g_tfInit3Ok && !g_tfReadError);
   bool anyError = (!wifiOk || !mqttOk || !tcaOk || !tfOk);
-  bool anyWarn  = (g_commFailCount > 0 || g_tfReadError);
 
   // Pixel 1: WiFi
   if (!wifiOk) setPixStatus(1, ST_PENDING);   // trying / not connected yet


### PR DESCRIPTION
## Summary
- remove unused warning flag in status LED update to clear compiler warning

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_693282648a988330834037ab57a8990c)