### PR TITLE
Add CORS headers to MeasurePi API responses

### DIFF
--- a/MeasurePi.py
+++ b/MeasurePi.py
@@ -477,6 +477,14 @@ def _start_serial_scale_reader_thread():
 # ─── Flask Web Application Routes ───────────────────────────────────────────
 app = Flask(__name__)
 
+
+@app.after_request
+def add_cors_headers(response):
+    response.headers["Access-Control-Allow-Origin"] = "*"
+    response.headers["Access-Control-Allow-Headers"] = "Content-Type, Authorization"
+    response.headers["Access-Control-Allow-Methods"] = "GET, POST, OPTIONS"
+    return response
+
 @app.route("/")
 def index_route():
     return render_template("index.html")


### PR DESCRIPTION
## Summary
- add a global after_request hook to include permissive CORS headers on all Flask responses
- enable cross-origin access for clients like the Tampermonkey userscript when triggering measurements

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69353304c244833088f2c5b0f5b39b9d)