### PR TITLE
Handle missing UPnP gateway identifier

### DIFF
--- a/MeasurePi.py
+++ b/MeasurePi.py
@@ -175,7 +175,11 @@ def _initialize_upnp_client():
         print(f"[UPNP] Failed to select Internet Gateway Device: {exc}")
         return None
 
-    print(f"[UPNP] Selected gateway {client.urlbase} (LAN: {client.lanaddr})")
+    gateway_id = getattr(client, "urlbase", None) or getattr(client, "location", None)
+    if gateway_id:
+        print(f"[UPNP] Selected gateway {gateway_id} (LAN: {client.lanaddr})")
+    else:
+        print(f"[UPNP] Selected gateway (LAN: {client.lanaddr})")
 
     try:
         external_ip = client.externalipaddress()


### PR DESCRIPTION
## Summary
- guard UPnP gateway logging when miniupnpc does not expose urlbase
- continue setup even when gateway identifier attribute is missing

## Testing
- python3 -m compileall MeasurePi.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6936615ddf0c832a85f5c9b4e19e23d2)