### PR TITLE
Raise minimum Flask port to 7000

### DIFF
--- a/MeasurePi.py
+++ b/MeasurePi.py
@@ -963,7 +963,14 @@ def manual_weight_api_route():
 def run_application():
     print("[SYSTEM] MeasurePi MQTT Client & Web Server is starting up...")
 
-    flask_port = int(os.getenv("FLASK_PORT", os.getenv("PORT", 5000)))
+    requested_port = int(os.getenv("FLASK_PORT", os.getenv("PORT", 7000)))
+    flask_port = max(7000, requested_port)
+
+    if flask_port != requested_port:
+        print(
+            f"[SYSTEM] Requested port {requested_port} is below the minimum allowed (7000); "
+            f"using {flask_port} instead."
+        )
 
     try:
         _init_lcd_if_present()


### PR DESCRIPTION
## Summary
- increase the Flask server's default port to 7000 and enforce a minimum of 7000 even when lower values are provided
- add logging when a requested port is below the allowed threshold

## Testing
- python -m compileall MeasurePi.py *(fails: SyntaxError at line 257 in existing code)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69410b44f5b88330901aab50bd398162)