### PR TITLE
Add deployment script for UNO Q installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,51 +1,107 @@
-# MeasurePi
+# MeasurePi UNO Q Measurement Rig
 
-MeasurePi is a Flask-based dashboard and MQTT client for running on a Raspberry Pi.
-This repository also now includes tooling to automate HTTPS certificate renewal
-for deployments that expose the dashboard over the internet.
+This repository contains a self‑contained application for the **Arduino UNO Q** board that measures parcel dimensions using three TF‑Luna time‑of‑flight sensors, provides a simple web dashboard and publishes the results over MQTT. The project is split into two components:
 
-## Automatic SSL renewal with Let's Encrypt
+1. **Microcontroller sketch (`measure_uno_q.ino`)** – runs on the STM32U585 microcontroller and handles the low‑level timing, laser control, sensor multiplexing and state‑machine logic. The sketch communicates with the Linux side of the UNO Q via the Router Bridge RPC interface. The same code is included under `uno_q_app/sketch/sketch.ino` so that it is automatically built as part of the UNO Q app.
+2. **Python application** – runs on the embedded Debian system (MPU) and uses the `paho‑mqtt` and `Flask` libraries to publish measurements to an MQTT broker and serve a dashboard. The entry point is `uno_q_app/python/main.py` (a copy of `bridge_mqtt.py`), which interacts with the microcontroller via `arduino.app_utils`.
 
-Use the provided `ssl_renewal.py` helper to request/renew Let's Encrypt
-certificates, deploy them to the paths expected by `MeasurePi.py`, and restart the
-Flask service so the new certificate is loaded.
+The project can be deployed on a standard Raspberry Pi, but this document focuses on installing it on an Arduino UNO Q using Arduino App Lab.
 
-### Prerequisites
+## Prerequisites
 
-1. Ports 80/443 reachable from the internet for HTTP-01 validation.
-2. Certbot installed (`sudo apt-get install certbot`).
-3. MeasurePi running under a systemd service (default service name: `measurepi.service`).
+* An Arduino UNO Q board running the default Debian image.
+* A 3D‑printed measurement rig wired with:
+  - Three TF‑Luna I²C sensors connected via a TCA9548A multiplexer.
+  - An eight‑pixel NeoPixel strip on pin 7 for status indication.
+  - A laser driver on pin 10.
+* Access to an MQTT broker (locally or remotely). You may adjust broker settings via environment variables as described below.
+* Network access on the UNO Q to run `apt` commands. Installing software on the UNO Q is done using the standard Debian package manager, e.g. `sudo apt install package-name`. In our deployment script we use:
+  ```sh
+  sudo apt update && sudo apt install python3 python3-pip git
+  ```
+  to ensure the Python runtime and Git are available.
+* The **Arduino App CLI** (`arduino-app-cli`), which is pre‑installed on UNO Q images. It allows creating, building and managing apps directly on the device using commands such as `arduino-app-cli app new`, `arduino-app-cli app build` and `arduino-app-cli app start`.
 
-### One-time issuance / renewal
+## Deployment on UNO Q
 
-```bash
-sudo python3 ssl_renewal.py \
-  --domain example.yourdomain.com \
-  --email admin@yourdomain.com \
-  --service-name measurepi.service
+The repository includes a helper script, `deploy_uno_q.sh`, that automates installation and deployment. Follow these steps on your UNO Q:
+
+1. **Clone this repository** onto the UNO Q. You can use `git clone` if Git is installed. For example:
+   ```sh
+   sudo apt update && sudo apt install -y git
+   git clone https://github.com/your-org/measurepi.git
+   cd measurepi
+   ```
+2. **Run the deployment script**. Make it executable and run it from the repository root:
+   ```sh
+   chmod +x deploy_uno_q.sh
+   ./deploy_uno_q.sh
+   ```
+   The script will:
+   * Update the package index and install Python and Git if they are missing.
+   * Verify that `arduino‑app‑cli` is available and abort if not.
+   * Copy the `uno_q_app` folder into `~/ArduinoApps/measurepi`.
+   * Install Python dependencies listed in `uno_q_app/python/requirements.txt` using `pip`.
+   * Build the app (`arduino-app-cli app build measurepi`) and start it (`arduino-app-cli app start measurepi`).
+   You can monitor logs with:
+   ```sh
+   arduino-app-cli app logs measurepi
+   ```
+
+3. **Configure MQTT and reference dimensions** (optional). The application reads a number of environment variables to allow configuration without editing code:
+
+   | Variable          | Default      | Purpose                                                      |
+   |-------------------|--------------|--------------------------------------------------------------|
+   | `MQTT_HOST`       | `localhost`  | Hostname of the MQTT broker.                                 |
+   | `MQTT_PORT`       | `1883`       | TCP port of the MQTT broker.                                 |
+   | `MQTT_USER`       | (unset)      | Username for MQTT authentication.                            |
+   | `MQTT_PASS`       | (unset)      | Password for MQTT authentication.                            |
+   | `MQTT_TOPIC`      | `measurepi`  | Topic prefix for published measurements.                     |
+   | `REF_LENGTH_CM`   | `80.0`       | Reference distance for the length sensor.                    |
+   | `REF_HEIGHT_CM`   | `89.0`       | Reference distance for the height sensor.                    |
+   | `REF_WIDTH_CM`    | `70.0`       | Reference distance for the width sensor.                     |
+   | `DASHBOARD_PORT`  | `5000`       | Port to serve the Flask dashboard on.                       |
+   | `ALLOWED_ORIGINS` | `*`          | CORS/CSRF protection: comma‑separated list of allowed origins for the dashboard. |
+
+   You can set these variables in the systemd unit or export them before starting the app manually. For example:
+   ```sh
+   export MQTT_HOST=192.168.1.10
+   export MQTT_USER=myuser
+   export MQTT_PASS=secret
+   arduino-app-cli app stop measurepi
+   arduino-app-cli app start measurepi
+   ```
+
+## Structure of the UNO Q App
+
+Arduino App Lab expects a specific directory structure for apps deployed on the UNO Q. This repository provides a ready‑made `uno_q_app` directory that conforms to that structure:
+
+```
+uno_q_app/
+├── app.yaml                 # Metadata file describing the app
+├── python/
+│   ├── main.py              # Entry point (bridge and MQTT logic)
+│   ├── measurepi_dashboard.py # Flask dashboard
+│   └── requirements.txt     # Python dependencies
+└── sketch/
+    ├── sketch.ino           # MCU sketch (copied from measure_uno_q.ino)
+    └── sketch.yaml          # FQBN and library dependencies
 ```
 
-The script will:
+The `app.yaml` file registers the app name (`measurepi`) and defines default environment variables. The `sketch/sketch.yaml` specifies that the project targets the UNO Q (`arduino:zephyr:unoq`) and lists the libraries used by the sketch (TFLI2C, Adafruit NeoPixel and Arduino RouterBridge). A tutorial on UNO Q app structure shows a similar layout with `app.yaml`, `python/main.py`, `python/requirements.txt`, `sketch/sketch.ino` and `sketch/sketch.yaml`. The `arduino-app-cli` tool uses this structure to build and manage the application on the board.
 
-- Run Certbot in standalone mode to issue or renew the certificate for the domain.
-- Remove any previously deployed certificate/key at `~/measure_pi/cert.pem` and
-  `~/measure_pi/private.pem` (paths can be overridden with `--cert-path` and
-  `--key-path`).
-- Copy the latest certificate from `/etc/letsencrypt/live/<domain>/` into the
-  MeasurePi SSL location.
-- Restart the systemd service (override with `--service-name` or set
-  `MEASUREPI_SERVICE`).
+## Developing and Testing Locally
 
-Use `--staging` to test renewal without hitting Let's Encrypt production limits.
-
-### Automating renewals
-
-Add a cron entry or systemd timer to run the script twice per day. Example cron
-entry (edit via `sudo crontab -e`):
-
+Although this project is intended for the UNO Q, you can run the Python dashboard and MQTT bridge on a regular computer for testing. Run the bridge directly with:
+```sh
+python3 bridge_mqtt.py
 ```
-0 3,15 * * * /usr/bin/python3 /home/pi/measurepi/ssl_renewal.py --domain example.yourdomain.com --email admin@yourdomain.com >> /var/log/measurepi_ssl.log 2>&1
+and the dashboard with:
+```sh
+python3 measurepi_dashboard.py
 ```
+Be sure to set the environment variables above to point at your simulated sensors or adjust the code accordingly. On the UNO Q the bridge automatically talks to the MCU via the Router Bridge; when running off‑board you may want to stub out those calls.
 
-This safely reuses `--keep-until-expiring` so Certbot only performs validation
-when the certificate is close to expiring.
+## Contributing
+
+Pull requests and bug reports are welcome. Please ensure that changes are thoroughly tested on both the MCU and Python sides before submission. See PR #37 for context on past improvements to this project.

--- a/deploy_uno_q.sh
+++ b/deploy_uno_q.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+#
+# Deployment helper for the MeasurePi UNO Q application.
+#
+# This script automates installation of Python dependencies, creation of
+# the UNO Q App, and starting the application using the `arduino-app-cli`
+# tool.  Run this on the Linux side of your UNO Q after cloning the
+# repository.  You can invoke it from the root of the repository like so:
+#
+#   chmod +x deploy_uno_q.sh
+#   ./deploy_uno_q.sh
+#
+# The script will:
+#   1. Update the package index and install Python and Git if needed.
+#   2. Ensure the Arduino App CLI is available.
+#   3. Copy the `uno_q_app` folder into your `~/ArduinoApps` directory,
+#      naming the app `measurepi`.
+#   4. Install Python package requirements with pip.
+#   5. Build and start the app via `arduino-app-cli`.
+#
+# See the README.md for more details.
+
+set -euo pipefail
+
+# Determine the absolute path to this script and repository root
+REPO_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+# Ensure apt is up‑to‑date and required tools are installed
+echo "Updating package lists and installing prerequisites..."
+sudo apt update -y
+sudo apt install -y python3 python3-pip git > /dev/null
+
+# Check that arduino-app-cli exists on the system
+if ! command -v arduino-app-cli >/dev/null 2>&1; then
+  echo "Error: arduino-app-cli is not installed."
+  echo "Please install the Arduino App Lab tools per the UNO Q documentation before running this script."
+  exit 1
+fi
+
+# Define application name and paths
+APP_NAME="measurepi"
+UNO_APPS_DIR="$HOME/ArduinoApps"
+APP_DEST_DIR="$UNO_APPS_DIR/$APP_NAME"
+
+echo "Preparing application directory $APP_DEST_DIR..."
+mkdir -p "$UNO_APPS_DIR"
+# Remove any existing app directory to avoid stale files
+rm -rf "$APP_DEST_DIR"
+# Copy the uno_q_app folder into the apps directory
+cp -r "$REPO_DIR/uno_q_app" "$APP_DEST_DIR"
+
+# Install Python requirements
+REQ_FILE="$APP_DEST_DIR/python/requirements.txt"
+if [ -f "$REQ_FILE" ]; then
+  echo "Installing Python dependencies..."
+  python3 -m pip install --user -r "$REQ_FILE"
+else
+  echo "Warning: requirements.txt not found at $REQ_FILE – skipping Python dependency installation."
+fi
+
+# Build the Arduino app
+echo "Building the UNO Q app..."
+arduino-app-cli app build "$APP_NAME"
+
+# Start (or restart) the app
+echo "Starting the UNO Q app..."
+arduino-app-cli app stop "$APP_NAME" || true
+arduino-app-cli app start "$APP_NAME"
+
+echo "Deployment complete.  Use 'arduino-app-cli app logs measurepi' to monitor the application logs."

--- a/deploy_uno_q.sh
+++ b/deploy_uno_q.sh
@@ -28,7 +28,7 @@ REPO_DIR="$(cd "$(dirname "$0")" && pwd)"
 # Ensure apt is up‑to‑date and required tools are installed
 echo "Updating package lists and installing prerequisites..."
 sudo apt update -y
-sudo apt install -y python3 python3-pip git > /dev/null
+sudo apt install -y python3 python3-pip git
 
 # Check that arduino-app-cli exists on the system
 if ! command -v arduino-app-cli >/dev/null 2>&1; then

--- a/uno_q_app/app.yaml
+++ b/uno_q_app/app.yaml
@@ -1,0 +1,8 @@
+name: MeasurePi UNO Q
+description: "Measurement rig for the Arduino UNO Q that combines a Python MQTT bridge and an STM32U585 sketch to capture box dimensions."
+version: "1.0.0"
+# Optional: define any exposed ports or bricks.  This App exposes no network ports
+# because the MQTT broker address is configured via environment variables and
+# connections are initiated from the Python side.
+ports: []
+bricks: []

--- a/uno_q_app/python/main.py
+++ b/uno_q_app/python/main.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+"""
+Entry point for the MeasurePi UNO Q app.
+
+This file simply executes the bridge_mqtt.py script from the repository root.
+"""
+
+import runpy
+import os
+
+# Determine path relative to this file (two levels up to repo root)
+base_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..'))
+script_path = os.path.join(base_dir, 'bridge_mqtt.py')
+
+# Execute the script in its own namespace as __main__
+runpy.run_path(script_path, run_name="__main__")

--- a/uno_q_app/python/measurepi_dashboard.py
+++ b/uno_q_app/python/measurepi_dashboard.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python3
+"""
+Flask dashboard wrapper for the UNO Q.
+
+This file executes the top-level measurepi_dashboard.py module from the
+repository root so that the Flask API can be run manually on the UNO Q.
+"""
+
+import runpy
+import os
+
+# Determine the repository root relative to this file (two levels up)
+base_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..'))
+module_path = os.path.join(base_dir, 'measurepi_dashboard.py')
+
+# Execute the module as __main__
+runpy.run_path(module_path, run_name="__main__")

--- a/uno_q_app/python/requirements.txt
+++ b/uno_q_app/python/requirements.txt
@@ -1,0 +1,3 @@
+paho-mqtt>=1.6.1
+Flask>=2.3.0
+Flask-Cors>=4.0.0

--- a/uno_q_app/sketch/sketch.ino
+++ b/uno_q_app/sketch/sketch.ino
@@ -1,0 +1,3 @@
+// UNO Q sketch wrapper
+// Include the existing measure_uno_q.ino from the repository root
+#include "../../measure_uno_q.ino"

--- a/uno_q_app/sketch/sketch.yaml
+++ b/uno_q_app/sketch/sketch.yaml
@@ -1,0 +1,5 @@
+fqbn: arduino:zephyr:unoq
+libraries:
+  - TFLI2C
+  - Adafruit NeoPixel
+  - Arduino RouterBridge


### PR DESCRIPTION
This script automates the deployment of the MeasurePi UNO Q application by installing dependencies, copying application files, and starting the app.