### PR TITLE
Add serial scale support to UNO Q bridge and include weight in MQTT payloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,19 @@ arduino-app-cli app stop measurepi
 arduino-app-cli app start measurepi
 ```
 
+### Optional serial scale integration
+
+If you connect a serial scale to the UNO Q (USB/tty device), the bridge can
+append weight data to the MQTT payloads it publishes. Configure the serial
+port settings with these environment variables:
+
+| Variable | Default | Purpose |
+| --- | --- | --- |
+| `SERIAL_SCALE_PORT` | `/dev/ttyUSB0` | Serial device path for the scale. |
+| `SERIAL_SCALE_BAUDRATE` | `9600` | Baud rate for the serial scale. |
+| `ENABLE_SERIAL_SCALE` | `true` | Enable the serial scale reader. |
+| `SERIAL_SCALE_RECONNECT_DELAY` | `3` | Seconds to wait before reconnecting. |
+
 ## UNO Q App Structure
 
 Arduino App Lab expects a specific directory layout. This repository provides a ready-made `uno_q_app` directory:

--- a/bridge_mqtt.py
+++ b/bridge_mqtt.py
@@ -28,6 +28,14 @@ reference distances used for calculating the box size:
 • ``REF_LENGTH_CM``, ``REF_HEIGHT_CM``, ``REF_WIDTH_CM`` – reference
 distances, in centimetres, measured from each sensor to the back wall
   with no box present (defaults mirror the UNO R4 sketch values)
+• ``SERIAL_SCALE_PORT`` – serial port for the external scale
+  (default ``/dev/ttyUSB0``)
+• ``SERIAL_SCALE_BAUDRATE`` – baud rate for the serial scale
+  (default ``9600``)
+• ``ENABLE_SERIAL_SCALE`` – enable the serial scale reader
+  (default ``true``)
+• ``SERIAL_SCALE_RECONNECT_DELAY`` – seconds between reconnect attempts
+  (default ``3``)
 
 The script registers the following bridge functions for use by the
 microcontroller sketch:
@@ -55,6 +63,7 @@ Version: Ver-2601110900
 import json
 import math
 import os
+import re
 import threading
 import time
 from typing import Optional
@@ -64,6 +73,7 @@ from arduino.app_utils import Bridge, App
 
 from collections import deque
 import html
+import serial
 
 # ─── Configuration ─────────────────────────────────────────
 
@@ -102,6 +112,15 @@ REF_LENGTH_CM = _get_float_env("REF_LENGTH_CM", 80.0)
 REF_HEIGHT_CM = _get_float_env("REF_HEIGHT_CM", 89.0)
 REF_WIDTH_CM = _get_float_env("REF_WIDTH_CM", 70.0)
 
+SERIAL_SCALE_PORT = os.getenv("SERIAL_SCALE_PORT", "/dev/ttyUSB0")
+SERIAL_SCALE_BAUDRATE = _get_int_env("SERIAL_SCALE_BAUDRATE", 9600)
+SERIAL_SCALE_ENABLED = os.getenv("ENABLE_SERIAL_SCALE", "true").lower() not in (
+    "0",
+    "false",
+    "no",
+)
+SERIAL_SCALE_RECONNECT_DELAY = _get_int_env("SERIAL_SCALE_RECONNECT_DELAY", 3)
+
 mqtt_client = mqtt.Client(client_id=MQTT_CLIENT_ID, protocol=mqtt.MQTTv311)
 
 if MQTT_USER:
@@ -112,6 +131,10 @@ if MQTT_USER:
 
 _log_lock = threading.Lock()
 _log_buffer: deque[str] = deque()
+_serial_scale_lock = threading.Lock()
+_serial_scale_thread: Optional[threading.Thread] = None
+_cached_serial_weight: Optional[float] = None
+_cached_serial_weight_timestamp: Optional[float] = None
 
 
 def _sanitize_log(msg: str) -> str:
@@ -213,6 +236,81 @@ def _box_dim_from_raw(ref_cm: float, raw: Optional[float]) -> Optional[float]:
     box = ref_cm - raw
     return max(box, 0.0)
 
+def _parse_serial_scale_line(line: str) -> Optional[float]:
+    if not isinstance(line, str):
+        return None
+    match = re.search(r"([-+]?\d+(?:\.\d+)?)", line)
+    if not match:
+        return None
+    return _safe_float(match.group(1))
+
+def _apply_serial_scale_weight(weight_value, source_line: Optional[str] = None) -> None:
+    if not isinstance(weight_value, (int, float)):
+        return
+    weight_float = float(weight_value)
+    timestamp = time.time()
+    with _serial_scale_lock:
+        global _cached_serial_weight, _cached_serial_weight_timestamp
+        _cached_serial_weight = weight_float
+        _cached_serial_weight_timestamp = timestamp
+    if source_line:
+        _log(f"[SERIAL-SCALE] Weight {weight_float:.3f} parsed from line: '{source_line}'")
+    else:
+        _log(f"[SERIAL-SCALE] Weight {weight_float:.3f} received from serial scale.")
+
+def _serial_scale_reader_loop() -> None:
+    if not SERIAL_SCALE_PORT:
+        _log("[SERIAL-SCALE] SERIAL_SCALE_PORT is not configured; skipping serial scale reader.")
+        return
+    _log(
+        f"[SERIAL-SCALE] Starting reader on {SERIAL_SCALE_PORT} at {SERIAL_SCALE_BAUDRATE} baud..."
+    )
+    while True:
+        try:
+            with serial.Serial(SERIAL_SCALE_PORT, SERIAL_SCALE_BAUDRATE, timeout=1) as ser:
+                _log(
+                    f"[SERIAL-SCALE] Connected to {SERIAL_SCALE_PORT}. Listening for weight data..."
+                )
+                while True:
+                    line_bytes = ser.readline()
+                    if not line_bytes:
+                        continue
+                    try:
+                        decoded = line_bytes.decode("utf-8", errors="ignore").strip()
+                    except Exception as exc:
+                        _log(f"[SERIAL-SCALE] Failed to decode serial data: {exc}")
+                        continue
+                    if not decoded:
+                        continue
+                    weight_val = _parse_serial_scale_line(decoded)
+                    if weight_val is None:
+                        continue
+                    _apply_serial_scale_weight(weight_val, decoded)
+        except serial.SerialException as exc:
+            _log(
+                f"[SERIAL-SCALE] Serial exception on {SERIAL_SCALE_PORT}: {exc}. "
+                f"Reconnecting in {SERIAL_SCALE_RECONNECT_DELAY}s..."
+            )
+            time.sleep(SERIAL_SCALE_RECONNECT_DELAY)
+        except Exception as exc:
+            _log(
+                f"[SERIAL-SCALE] Unexpected error while reading from {SERIAL_SCALE_PORT}: {exc}. "
+                f"Reconnecting in {SERIAL_SCALE_RECONNECT_DELAY}s..."
+            )
+            time.sleep(SERIAL_SCALE_RECONNECT_DELAY)
+
+def _start_serial_scale_reader_thread() -> None:
+    global _serial_scale_thread
+    if not SERIAL_SCALE_ENABLED:
+        _log("[SERIAL-SCALE] Serial scale reader disabled via ENABLE_SERIAL_SCALE flag.")
+        return
+    if _serial_scale_thread and _serial_scale_thread.is_alive():
+        return
+    _serial_scale_thread = threading.Thread(
+        target=_serial_scale_reader_loop, name="SerialScaleReader", daemon=True
+    )
+    _serial_scale_thread.start()
+
 def measurement_data(height_raw, width_raw, length_raw) -> None:
     h_raw = _safe_float(height_raw)
     w_raw = _safe_float(width_raw)
@@ -234,6 +332,21 @@ def measurement_data(height_raw, width_raw, length_raw) -> None:
         "width_box": w_box,
         "length_box": l_box,
     }
+    with _serial_scale_lock:
+        cached_weight = _cached_serial_weight
+        cached_weight_ts = _cached_serial_weight_timestamp
+    if cached_weight is not None:
+        payload.update(
+            {
+                "weight": cached_weight,
+                "weight_net": cached_weight,
+                "weight_gross": cached_weight,
+                "weight_timestamp": cached_weight_ts,
+                "weight_source": "serial_scale",
+                "scale_present": True,
+                "serial_scale_port": SERIAL_SCALE_PORT,
+            }
+        )
     try:
         mqtt_client.publish(MQTT_DATA_TOPIC, json.dumps(payload), qos=0, retain=False)
         _log("[MQTT] Published measurement payload.")
@@ -258,6 +371,7 @@ def _user_loop() -> None:
 def main() -> None:
     _log("[SYSTEM] UNO Q MQTT bridge starting…")
     _start_mqtt()
+    _start_serial_scale_reader_thread()
     App.run(user_loop=_user_loop)
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Motivation

- Ensure weight measurements that were previously read over a serial scale in `MeasurePi.py` are available to the UNO Q bridge so weight appears in published MQTT payloads.
- Provide an opt-in serial scale integration on the UNO Q Linux side to mirror the Raspberry Pi behavior (cached weight, source metadata, and scale presence).

### Description

- Implemented a serial scale reader in `bridge_mqtt.py` including `_parse_serial_scale_line`, `_apply_serial_scale_weight`, a `_serial_scale_reader_loop` and `_start_serial_scale_reader_thread` that runs at startup.
- Added configuration environment variables `SERIAL_SCALE_PORT`, `SERIAL_SCALE_BAUDRATE`, `ENABLE_SERIAL_SCALE`, and `SERIAL_SCALE_RECONNECT_DELAY` and a thread-safe cached weight store used when assembling MQTT payloads.
- When a cached serial weight is available the bridge appends `weight`, `weight_net`, `weight_gross`, `weight_timestamp`, `weight_source`, `scale_present`, and `serial_scale_port` fields to the measurement JSON published to `MQTT_DATA_TOPIC`.
- Documented the optional serial scale environment variables and usage in `README.md`.

### Testing

- Ran `python -m py_compile bridge_mqtt.py` and it succeeded with no syntax errors.
- Attempted `python -m ruff bridge_mqtt.py` which failed due to an incorrect invocation of ruff (usage error).
- Ran `ruff check bridge_mqtt.py` (the correct linter invocation) and it passed with no issues.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_696457033f4c8330a7c594ae933a527b)