### PR TITLE
Add UNO Q deployment helper script

### DIFF
--- a/deploy_uno_q.sh
+++ b/deploy_uno_q.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+APP_NAME="measurepi"
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SOURCE_DIR="${REPO_ROOT}/uno_q_app"
+TARGET_DIR="${HOME}/ArduinoApps/${APP_NAME}"
+
+log() {
+  printf '\n[%s] %s\n' "${APP_NAME}" "$1"
+}
+
+if ! command -v arduino-app-cli >/dev/null 2>&1; then
+  echo "Error: arduino-app-cli is not installed or not on PATH." >&2
+  echo "Install Arduino App CLI before running this script." >&2
+  exit 1
+fi
+
+if [[ ! -d "${SOURCE_DIR}" ]]; then
+  echo "Error: expected ${SOURCE_DIR} to exist." >&2
+  echo "Ensure the repository includes the uno_q_app directory." >&2
+  exit 1
+fi
+
+log "Updating package index and installing dependencies"
+sudo apt update
+sudo apt install -y git python3 python3-pip
+
+log "Deploying UNO Q app to ${TARGET_DIR}"
+mkdir -p "${HOME}/ArduinoApps"
+rm -rf "${TARGET_DIR}"
+cp -a "${SOURCE_DIR}" "${TARGET_DIR}"
+
+if [[ -f "${TARGET_DIR}/python/requirements.txt" ]]; then
+  log "Installing Python dependencies"
+  python3 -m pip install --user -r "${TARGET_DIR}/python/requirements.txt"
+else
+  log "Skipping Python dependencies (requirements.txt not found)"
+fi
+
+log "Building and starting ${APP_NAME}"
+arduino-app-cli app build "${APP_NAME}"
+arduino-app-cli app start "${APP_NAME}"
+
+log "Deployment complete"


### PR DESCRIPTION
### Motivation
- Automate the README-described deployment steps for the Arduino UNO Q to make installing and running the app on-device simple and repeatable.
- Validate prerequisites and fail fast when required tools or repository layout are missing.

### Description
- Add `deploy_uno_q.sh`, a POSIX-style script that sets `REPO_ROOT` and deploys `uno_q_app` into `~/ArduinoApps/measurepi` while using `set -euo pipefail` for safety.
- The script checks for `arduino-app-cli` and the presence of `uno_q_app`, updates `apt` and installs `git`, `python3`, and `python3-pip`, and copies the app into the target directory.
- If `python/requirements.txt` exists in the deployed app it installs Python dependencies with `python3 -m pip install --user -r ...`.
- The script builds and starts the app via `arduino-app-cli app build <app>` and `arduino-app-cli app start <app>`, and prints progress with a small `log()` helper.

### Testing
- Ran a syntax check with `bash -n deploy_uno_q.sh`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_696adeff3a648330b0000a6214f84dbd)