### PR TITLE
Handle missing UNO Q app bundle in deploy script

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ MeasurePi is a self-contained application for the **Arduino UNO Q** that measure
 
 ## Deployment on UNO Q
 
-The repository includes a helper script, `deploy_uno_q.sh`, that automates installation and deployment.
+The repository includes a helper script, `deploy_uno_q.sh`, that automates installation and deployment. If the `uno_q_app` directory is missing, the script will generate the app bundle from the repository sources (sketch, bridge, dashboard, and templates).
 
 1. **Clone this repository** onto the UNO Q.
    ```bash
@@ -88,7 +88,7 @@ arduino-app-cli app start measurepi
 
 ## UNO Q App Structure
 
-Arduino App Lab expects a specific directory layout. This repository provides a ready-made `uno_q_app` directory:
+Arduino App Lab expects a specific directory layout. This repository provides a ready-made `uno_q_app` directory, and the deployment script can generate one if it is missing:
 
 ```
 uno_q_app/

--- a/deploy_uno_q.sh
+++ b/deploy_uno_q.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+APP_NAME="measurepi"
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SOURCE_DIR="${REPO_ROOT}/uno_q_app"
+TARGET_DIR="${HOME}/ArduinoApps/${APP_NAME}"
+TEMP_DIR=""
+
+log() {
+  printf '\n[%s] %s\n' "${APP_NAME}" "$1"
+}
+
+if ! command -v arduino-app-cli >/dev/null 2>&1; then
+  echo "Error: arduino-app-cli is not installed or not on PATH." >&2
+  echo "Install Arduino App CLI before running this script." >&2
+  exit 1
+fi
+
+cleanup() {
+  if [[ -n "${TEMP_DIR}" && -d "${TEMP_DIR}" ]]; then
+    rm -rf "${TEMP_DIR}"
+  fi
+}
+
+create_app_bundle() {
+  local destination="$1"
+  local sketch_source="${REPO_ROOT}/measure_uno_q.ino"
+  local bridge_source="${REPO_ROOT}/bridge_mqtt.py"
+  local dashboard_source="${REPO_ROOT}/measurepi_dashboard.py"
+  local templates_source="${REPO_ROOT}/templates"
+
+  if [[ ! -f "${sketch_source}" || ! -f "${bridge_source}" || ! -f "${dashboard_source}" ]]; then
+    echo "Error: missing required source files in ${REPO_ROOT}." >&2
+    exit 1
+  fi
+
+  log "uno_q_app not found; generating app bundle from repository sources"
+  mkdir -p "${destination}/sketch" "${destination}/python"
+
+  cp "${sketch_source}" "${destination}/sketch/sketch.ino"
+  cp "${bridge_source}" "${destination}/python/main.py"
+  cp "${dashboard_source}" "${destination}/python/measurepi_dashboard.py"
+
+  if [[ -d "${templates_source}" ]]; then
+    cp -a "${templates_source}" "${destination}/python/templates"
+  fi
+
+  cat <<'EOF' > "${destination}/python/requirements.txt"
+paho-mqtt
+Flask
+EOF
+
+  cat <<'EOF' > "${destination}/sketch/sketch.yaml"
+fqbn: arduino:zephyr:unoq
+libraries:
+  - name: TFLI2C
+  - name: Adafruit NeoPixel
+  - name: Arduino RouterBridge
+EOF
+
+  cat <<'EOF' > "${destination}/app.yaml"
+name: measurepi
+version: 1.0.0
+description: MeasurePi UNO Q app bundle
+services:
+  - name: measurepi
+    type: python
+    entrypoint: python/main.py
+EOF
+}
+
+if [[ ! -d "${SOURCE_DIR}" ]]; then
+  TEMP_DIR="$(mktemp -d)"
+  trap cleanup EXIT
+  create_app_bundle "${TEMP_DIR}/uno_q_app"
+  SOURCE_DIR="${TEMP_DIR}/uno_q_app"
+fi
+
+log "Updating package index and installing dependencies"
+sudo apt update
+sudo apt install -y git python3 python3-pip
+
+log "Deploying UNO Q app to ${TARGET_DIR}"
+mkdir -p "${HOME}/ArduinoApps"
+rm -rf "${TARGET_DIR}"
+cp -a "${SOURCE_DIR}" "${TARGET_DIR}"
+
+if [[ -f "${TARGET_DIR}/python/requirements.txt" ]]; then
+  log "Installing Python dependencies"
+  python3 -m pip install --user -r "${TARGET_DIR}/python/requirements.txt"
+else
+  log "Skipping Python dependencies (requirements.txt not found)"
+fi
+
+log "Building and starting ${APP_NAME}"
+arduino-app-cli app build "${APP_NAME}"
+arduino-app-cli app start "${APP_NAME}"
+
+log "Deployment complete"


### PR DESCRIPTION
### Motivation
- The deployment script previously failed when the `uno_q_app` directory was absent, causing `Error: expected /measurepi/uno_q_app to exist.` during on-device deployment.
- The intent is to make `deploy_uno_q.sh` robust so the app can be deployed directly from the repository without a pre-built `uno_q_app` directory.

### Description
- Update `deploy_uno_q.sh` to auto-generate a valid `uno_q_app` bundle from repository sources (`measure_uno_q.ino`, `bridge_mqtt.py`, `measurepi_dashboard.py`, and `templates`) when `uno_q_app` is missing by adding a `create_app_bundle()` helper.
- Add temporary directory handling and cleanup with `TEMP_DIR`, a `cleanup()` function, and `trap cleanup EXIT` to remove generated artifacts after use.
- Generate `python/requirements.txt`, `sketch/sketch.yaml`, and `app.yaml` programmatically to satisfy Arduino App Lab layout and dependency expectations.
- Update `README.md` to document that the deployment script can generate the `uno_q_app` bundle when it is not present.

### Testing
- Ran a syntax check with `bash -n deploy_uno_q.sh`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_696adeff3a648330b0000a6214f84dbd)