### PR TITLE
Fix TF‑Luna init function and remove duplicated lines causing nested defs

### DIFF
--- a/measure_uno_q.ino
+++ b/measure_uno_q.ino
@@ -289,19 +289,19 @@ static void tflStartContinuous(uint8_t addr) {
 }
 
 static bool tflInit(uint8_t addr, const char* name, bool &flagOk) {
-
   Wire.beginTransmission(addr);
-  if (Wire.endTransmission() != 0) {
-    logf("[TF] %s: sensor not found at addr 0x%02X", name, addr);
-    flagOk = false;
-Wire.beginTransmission(addr);
   if (Wire.endTransmission() != 0) {
     logf("[TF] %s: sensor not found at addr 0x%02X", name, addr);
     flagOk = false;
     return false;
   }
-
-
+  delay(5);
+  tflStartContinuous(addr);
+  delay(5);
+  logf("[TF] %s: init OK addr 0x%02X", name, addr);
+  flagOk = true;
+  return true;
+}
 
 static int16_t tflReadOnceDRDY(uint8_t addr, uint8_t rtsPin) {
   if (!waitRTSHigh(rtsPin, DRDY_TIMEOUT_MS)) {


### PR DESCRIPTION
### Motivation
- Resolve compile errors caused by an unterminated/duplicated `tflInit` implementation that produced nested function definitions.
- Ensure a successful TF‑Luna initialization sequence performs an I2C probe and then starts continuous mode for sampling.

### Description
- Removed duplicated/incorrect `Wire.beginTransmission`/probe lines and closed the `tflInit` function properly to avoid nested function definitions.
- After a successful I2C probe `tflInit` now calls `tflStartContinuous(addr)` with small delays before and after to start the sensor in continuous mode.
- `tflInit` sets `flagOk = true`, logs an init success message, and returns `true` on success.

### Testing
- Attempted to run the Arduino app build with `arduino-app-cli app build measurepi`, which failed because `arduino-app-cli` is not available in this environment. (build not performed)
- Performed static source inspection (`nl`/`sed`/`rg`) to verify the function closure and surrounding code are syntactically correct, with no nested function definitions remaining.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_696afabdee0c83309598c6a93bd99cfb)