### PR TITLE
Separate dashboard startup from bridge; add MQTT auth to dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,9 @@ Older Raspberry Pi and UNO R4 WiFi assets have been moved into the `legacy/` dir
 
 ## Developing and Testing Locally
 
-You can run the Python dashboard and MQTT bridge on a regular computer for testing:
+You can run the Python dashboard and MQTT bridge on a regular computer for testing. The
+bridge and dashboard now run as separate processes, so start each script in its own
+terminal session:
 
 ```bash
 python3 bridge_mqtt.py

--- a/bridge_mqtt.py
+++ b/bridge_mqtt.py
@@ -22,13 +22,6 @@ reference distances used for calculating the box size:
 • MQTT_CLIENT_ID – MQTT client identifier (default uno-q-bridge)
 • REF_LENGTH_CM, REF_HEIGHT_CM, REF_WIDTH_CM – reference distances, in centimetres
 
-Patch notes (this version):
-- Starts measurepi_dashboard.run_application() in a background daemon thread
-  BEFORE App.run(...), so one process can host both services.
-- Unifies MQTT defaults by exporting the bridge’s resolved env values to the
-  process environment BEFORE importing the dashboard module, so the dashboard
-  doesn’t quietly fall back to localhost while the bridge uses 10.1.1.85.
-
 Version: Ver-2601172142
 """
 
@@ -247,74 +240,9 @@ def _user_loop() -> None:
     time.sleep(0.1)
 
 
-# ─── Dashboard integration (patched) ─────────────────────────
-
-_dashboard_thread: Optional[threading.Thread] = None
-
-
-def _sync_mqtt_env_defaults_for_dashboard() -> None:
-    """
-    Ensure the dashboard sees the same MQTT settings as the bridge.
-
-    The dashboard reads MQTT_* env vars at import time (module-level constants).
-    So we set defaults here BEFORE importing measurepi_dashboard.
-    We only set values that are missing, so explicit env vars always win.
-    """
-    os.environ.setdefault("MQTT_BROKER", str(MQTT_BROKER))
-    os.environ.setdefault("MQTT_PORT", str(MQTT_PORT))
-    os.environ.setdefault("MQTT_CMD_TOPIC", str(MQTT_CMD_TOPIC))
-    os.environ.setdefault("MQTT_DATA_TOPIC", str(MQTT_DATA_TOPIC))
-    os.environ.setdefault("MQTT_LOG_TOPIC", str(MQTT_LOG_TOPIC))
-
-    # If broker auth is set for bridge, propagate it too (dashboard will ignore if unused).
-    if MQTT_USER:
-        os.environ.setdefault("MQTT_USER", str(MQTT_USER))
-    if MQTT_PASS is not None:
-        os.environ.setdefault("MQTT_PASS", str(MQTT_PASS))
-
-
-def _start_dashboard_thread() -> None:
-    """
-    Start the Flask dashboard in a background daemon thread.
-
-    Can be disabled by setting START_DASHBOARD=0/false/no.
-    """
-    global _dashboard_thread
-
-    raw = (os.getenv("START_DASHBOARD", "1") or "").strip().lower()
-    if raw in {"0", "false", "no", "off"}:
-        _log("[DASH] START_DASHBOARD disabled; not starting dashboard thread.")
-        return
-
-    if _dashboard_thread and _dashboard_thread.is_alive():
-        _log("[DASH] Dashboard thread already running.")
-        return
-
-    _sync_mqtt_env_defaults_for_dashboard()
-
-    def _runner():
-        try:
-            _log("[DASH] Starting measurepi_dashboard.run_application()…")
-            # Import AFTER env sync so dashboard doesn’t default to localhost.
-            import measurepi_dashboard  # noqa: F401
-            measurepi_dashboard.run_application()
-        except Exception as e:
-            _log(f"[DASH] Dashboard thread crashed: {e}")
-
-    _dashboard_thread = threading.Thread(
-        target=_runner,
-        name="measurepi_dashboard",
-        daemon=True,
-    )
-    _dashboard_thread.start()
-
-
 def main() -> None:
     _log("[SYSTEM] UNO Q MQTT bridge starting…")
     _start_mqtt()
-
-    # Patched: start dashboard BEFORE App.run(...) blocks forever.
-    _start_dashboard_thread()
 
     App.run(user_loop=_user_loop)
 

--- a/measurepi_dashboard.py
+++ b/measurepi_dashboard.py
@@ -45,6 +45,8 @@ except ValueError:
 MQTT_TOPIC_SUB = os.getenv("MQTT_DATA_TOPIC", "measure/data")
 MQTT_TOPIC_LOG = os.getenv("MQTT_LOG_TOPIC", "measure/log")
 MQTT_COMMAND_TOPIC = os.getenv("MQTT_CMD_TOPIC", "measure/cmd")
+MQTT_USER = os.getenv("MQTT_USER")
+MQTT_PASS = os.getenv("MQTT_PASS")
 
 # Number of raw MQTT payloads and log messages to keep in memory
 MAX_RAW_HISTORY = 200
@@ -69,6 +71,11 @@ awaiting_manual_weight = False
 pending_manual_weight_value = None
 
 mqtt_client = mqtt.Client(client_id=f"measurepi_dashboard_{os.getpid()}", protocol=mqtt.MQTTv311)
+if MQTT_USER:
+    if MQTT_PASS is not None:
+        mqtt_client.username_pw_set(MQTT_USER, MQTT_PASS)
+    else:
+        mqtt_client.username_pw_set(MQTT_USER)
 
 # ─── Helper Functions ─────────────────────
 


### PR DESCRIPTION
### Motivation

- Decouple the Flask dashboard from the MQTT bridge so each can be run as an independent process for clearer deployment and simpler lifecycle management.
- Ensure the standalone dashboard can connect to brokers that require authentication by adding optional MQTT username/password support.
- Update local development docs to reflect the new preferred workflow of running the bridge and dashboard separately.

### Description

- Removed the dashboard thread/bootstrap logic from `bridge_mqtt.py` so the bridge no longer starts `measurepi_dashboard` in-process and now only runs the MQTT bridge and Router Bridge loop.
- Added reading of `MQTT_USER` and `MQTT_PASS` in `measurepi_dashboard.py` and configured the dashboard `paho.mqtt.client.Client` with `username_pw_set` when credentials are present.
- Clarified the README instructions to tell developers to start `bridge_mqtt.py` and `measurepi_dashboard.py` in separate terminals for local testing.

### Testing

- Ran `python -m py_compile measurepi_dashboard.py bridge_mqtt.py` which completed successfully with no syntax errors.
- Ran `python -m unittest discover` which found 0 tests and exited `OK`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_696b1e1a0018833095101aecd3ec44f8)