### PR TITLE
Separate MQTT process from bridge

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ MeasurePi is a self-contained application for the **Arduino UNO Q** that measure
    * Runs on the embedded Debian system (MPU).
    * Publishes measurements to an MQTT broker using `paho-mqtt`.
    * Serves a Flask dashboard for live readings.
-   * Entry point: `uno_q_app/python/main.py` (a copy of `bridge_mqtt.py`).
+   * Entry points: `bridge_mqtt.py` (UNO Q bridge) and `mqtt_server.py` (MQTT process).
 
 ## Prerequisites
 
@@ -66,20 +66,27 @@ The application reads environment variables so you can adjust settings without e
 
 | Variable | Default | Purpose |
 | --- | --- | --- |
-| `MQTT_HOST` | `localhost` | MQTT broker hostname. |
-| `MQTT_PORT` | `1883` | MQTT broker port. |
-| `MQTT_USER` | (unset) | MQTT username. |
-| `MQTT_PASS` | (unset) | MQTT password. |
-| `MQTT_TOPIC` | `measurepi` | Topic prefix for published measurements. |
-| `REF_LENGTH_CM` | `80.0` | Reference distance for the length sensor. |
-| `REF_HEIGHT_CM` | `89.0` | Reference distance for the height sensor. |
-| `REF_WIDTH_CM` | `70.0` | Reference distance for the width sensor. |
+| `MQTT_BROKER` | `10.1.1.85` | MQTT broker hostname or IP (mqtt_server.py). |
+| `MQTT_PORT` | `1883` | MQTT broker port (mqtt_server.py). |
+| `MQTT_USER` | (unset) | MQTT username (mqtt_server.py). |
+| `MQTT_PASS` | (unset) | MQTT password (mqtt_server.py). |
+| `MQTT_CMD_TOPIC` | `measure/cmd` | Topic for capture commands (mqtt_server.py). |
+| `MQTT_DATA_TOPIC` | `measure/data` | Topic for published measurement payloads (mqtt_server.py). |
+| `MQTT_LOG_TOPIC` | `measure/log` | Topic for log messages (mqtt_server.py). |
+| `MQTT_CLIENT_ID` | `uno-q-bridge` | MQTT client identifier (mqtt_server.py). |
+| `MQTT_IPC_HOST` | `127.0.0.1` | Host for bridge → MQTT IPC (both processes). |
+| `MQTT_IPC_PORT` | `8765` | Port for bridge → MQTT IPC (both processes). |
+| `BRIDGE_CMD_HOST` | `127.0.0.1` | Host for MQTT → bridge command IPC (both processes). |
+| `BRIDGE_CMD_PORT` | `8766` | Port for MQTT → bridge command IPC (both processes). |
+| `REF_LENGTH_CM` | `80.0` | Reference distance for the length sensor (bridge_mqtt.py). |
+| `REF_HEIGHT_CM` | `89.0` | Reference distance for the height sensor (bridge_mqtt.py). |
+| `REF_WIDTH_CM` | `70.0` | Reference distance for the width sensor (bridge_mqtt.py). |
 | `DASHBOARD_PORT` | `5000` | Flask dashboard port. |
 | `ALLOWED_ORIGINS` | `*` | Comma-separated list of allowed dashboard origins. |
 
 Example:
 ```bash
-export MQTT_HOST=192.168.1.10
+export MQTT_BROKER=192.168.1.10
 export MQTT_USER=myuser
 export MQTT_PASS=secret
 arduino-app-cli app stop measurepi
@@ -114,11 +121,12 @@ Older Raspberry Pi and UNO R4 WiFi assets have been moved into the `legacy/` dir
 ## Developing and Testing Locally
 
 You can run the Python dashboard and MQTT bridge on a regular computer for testing. The
-bridge and dashboard now run as separate processes, so start each script in its own
-terminal session:
+bridge, MQTT server, and dashboard now run as separate processes, so start each script
+in its own terminal session:
 
 ```bash
 python3 bridge_mqtt.py
+python3 mqtt_server.py
 python3 measurepi_dashboard.py
 ```
 

--- a/bridge_mqtt.py
+++ b/bridge_mqtt.py
@@ -4,42 +4,60 @@
 bridge_mqtt.py – Python bridge for the UNO Q measure rig
 
 This script runs on the Linux side of an Arduino UNO Q board and
-coordinates communication between the microcontroller sketch and an
-MQTT broker. It listens for raw measurement data from the MCU via the
-Router Bridge RPC interface, computes box dimensions from the raw
-distances, and publishes JSON payloads to MQTT. It also subscribes
-to a command topic and forwards capture requests back to the MCU.
+coordinates communication between the microcontroller sketch and the
+local MQTT process. It listens for raw measurement data from the MCU
+via the Router Bridge RPC interface, computes box dimensions from the
+raw distances, and forwards JSON payloads to the MQTT process over a
+local IPC socket. It also listens for capture commands over a local
+command socket and forwards requests back to the MCU.
 
-Environment variables control the broker address, credentials and
-reference distances used for calculating the box size:
+Environment variables control the IPC endpoints and reference distances
+used for calculating the box size:
 
-• MQTT_BROKER – hostname or IP address of the MQTT server (default 10.1.1.85)
-• MQTT_PORT  – port number of the MQTT server (default 1883)
-• MQTT_USER / MQTT_PASS – optional username/password for authenticated brokers
-• MQTT_CMD_TOPIC – topic to listen for capture commands (default measure/cmd)
-• MQTT_DATA_TOPIC – topic to publish measurement data to (default measure/data)
-• MQTT_LOG_TOPIC – topic to publish log messages to (default measure/log)
-• MQTT_CLIENT_ID – MQTT client identifier (default uno-q-bridge)
+• MQTT_IPC_HOST / MQTT_IPC_PORT – host/port for sending payloads to the MQTT process
+• BRIDGE_CMD_HOST / BRIDGE_CMD_PORT – host/port for receiving command requests
 • REF_LENGTH_CM, REF_HEIGHT_CM, REF_WIDTH_CM – reference distances, in centimetres
 
 Version: Ver-2601172142
 """
 
+import html
 import json
 import math
 import os
+import socket
+import socketserver
 import threading
 import time
 from typing import Optional
 
-import paho.mqtt.client as mqtt
 from arduino.app_utils import Bridge, App
-
-from collections import deque
-import html
 
 
 # ─── Configuration ─────────────────────────────────────────
+
+_IPC_READY = False
+
+
+def _sanitize_log(msg: str) -> str:
+    """Sanitize a log message before printing/publishing."""
+    msg_str = str(msg)
+    escaped = html.escape(msg_str)
+    sanitized_chars = []
+    for ch in escaped:
+        if ch in "\n\r" or not ch.isprintable():
+            sanitized_chars.append(" ")
+        else:
+            sanitized_chars.append(ch)
+    return "".join(sanitized_chars)
+
+
+def _log(msg: str) -> None:
+    msg = _sanitize_log(str(msg))
+    print(msg)
+    if _IPC_READY:
+        _send_ipc_message({"type": "log", "message": msg})
+
 
 def _get_int_env(name: str, default: int) -> int:
     raw = os.getenv(name)
@@ -63,105 +81,14 @@ def _get_float_env(name: str, default: float) -> float:
         return default
 
 
-DEFAULT_MQTT_BROKER = "10.1.1.85"
-DEFAULT_MQTT_PORT = 1883
-
-MQTT_BROKER = os.getenv("MQTT_BROKER", DEFAULT_MQTT_BROKER)
-MQTT_PORT = _get_int_env("MQTT_PORT", DEFAULT_MQTT_PORT)
-MQTT_USER = os.getenv("MQTT_USER")
-MQTT_PASS = os.getenv("MQTT_PASS")
-
-MQTT_CMD_TOPIC = os.getenv("MQTT_CMD_TOPIC", "measure/cmd")
-MQTT_DATA_TOPIC = os.getenv("MQTT_DATA_TOPIC", "measure/data")
-MQTT_LOG_TOPIC = os.getenv("MQTT_LOG_TOPIC", "measure/log")
-MQTT_CLIENT_ID = os.getenv("MQTT_CLIENT_ID", "uno-q-bridge")
+MQTT_IPC_HOST = os.getenv("MQTT_IPC_HOST", "127.0.0.1")
+MQTT_IPC_PORT = _get_int_env("MQTT_IPC_PORT", 8765)
+BRIDGE_CMD_HOST = os.getenv("BRIDGE_CMD_HOST", "127.0.0.1")
+BRIDGE_CMD_PORT = _get_int_env("BRIDGE_CMD_PORT", 8766)
 
 REF_LENGTH_CM = _get_float_env("REF_LENGTH_CM", 80.0)
 REF_HEIGHT_CM = _get_float_env("REF_HEIGHT_CM", 89.0)
 REF_WIDTH_CM = _get_float_env("REF_WIDTH_CM", 70.0)
-
-mqtt_client = mqtt.Client(client_id=MQTT_CLIENT_ID, protocol=mqtt.MQTTv311)
-
-if MQTT_USER:
-    if MQTT_PASS is not None:
-        mqtt_client.username_pw_set(MQTT_USER, MQTT_PASS)
-    else:
-        mqtt_client.username_pw_set(MQTT_USER)
-
-
-_log_lock = threading.Lock()
-_log_buffer: deque[str] = deque()
-
-
-def _sanitize_log(msg: str) -> str:
-    """Sanitize a log message before printing/publishing."""
-    msg_str = str(msg)
-    escaped = html.escape(msg_str)
-    sanitized_chars = []
-    for ch in escaped:
-        if ch in "\n\r" or not ch.isprintable():
-            sanitized_chars.append(" ")
-        else:
-            sanitized_chars.append(ch)
-    return "".join(sanitized_chars)
-
-
-def _log(msg: str) -> None:
-    msg = _sanitize_log(str(msg))
-    print(msg)
-    with _log_lock:
-        _log_buffer.append(msg)
-
-
-def _flush_log() -> None:
-    if not mqtt_client.is_connected():
-        with _log_lock:
-            _log_buffer.clear()
-        return
-    with _log_lock:
-        while _log_buffer:
-            line = _log_buffer.popleft()
-            try:
-                mqtt_client.publish(MQTT_LOG_TOPIC, line, qos=0, retain=False)
-            except Exception:
-                _log_buffer.appendleft(line)
-                break
-
-
-def _on_mqtt_connect(client, userdata, flags, rc, properties=None):
-    if rc == 0:
-        _log(f"[MQTT] Connected to {MQTT_BROKER}:{MQTT_PORT} as {MQTT_CLIENT_ID}.")
-        client.subscribe(MQTT_CMD_TOPIC)
-        _log(f"[MQTT] Subscribed to command topic '{MQTT_CMD_TOPIC}'.")
-    else:
-        _log(f"[MQTT] Connection failed with code {rc}.")
-
-
-def _on_mqtt_disconnect(client, userdata, rc, properties=None):
-    if rc != 0:
-        _log(f"[MQTT] Unexpected disconnect (rc={rc}). Will retry automatically.")
-
-
-def _on_mqtt_message(client, userdata, msg):
-    try:
-        payload = msg.payload.decode("utf-8", errors="replace").strip()
-    except Exception:
-        payload = repr(msg.payload)
-    _log(f"[MQTT] Received message on '{msg.topic}': {payload}")
-    if msg.topic != MQTT_CMD_TOPIC:
-        return
-    if payload.lower().startswith("cap"):
-        _log("[BRIDGE] Capture command received via MQTT. Invoking MCU 'capture' function…")
-        try:
-            bridge.call("capture")
-        except Exception as e:
-            _log(f"[BRIDGE] Error invoking 'capture': {e}")
-
-
-mqtt_client.on_connect = _on_mqtt_connect
-mqtt_client.on_disconnect = _on_mqtt_disconnect
-mqtt_client.on_message = _on_mqtt_message
-
 
 bridge = Bridge()
 
@@ -215,36 +142,72 @@ def measurement_data(height_raw, width_raw, length_raw) -> None:
         "length_box": l_box,
     }
 
-    try:
-        mqtt_client.publish(MQTT_DATA_TOPIC, json.dumps(payload), qos=0, retain=False)
-        _log("[MQTT] Published measurement payload.")
-    except Exception as e:
-        _log(f"[MQTT] Failed to publish measurement: {e}")
+    _send_ipc_message({"type": "measurement", "payload": payload})
 
 
 bridge.provide("linux_started", linux_started)
 bridge.provide("mcu_ready", mcu_ready)
 bridge.provide("measurement_data", measurement_data)
 
-
-def _start_mqtt():
+def _send_ipc_message(message: dict) -> None:
     try:
-        mqtt_client.connect(MQTT_BROKER, MQTT_PORT, keepalive=60)
-        mqtt_client.loop_start()
-    except Exception as e:
-        _log(f"[MQTT] Failed to connect to broker at {MQTT_BROKER}:{MQTT_PORT}: {e}")
+        data = json.dumps(message, separators=(",", ":")).encode("utf-8") + b"\n"
+        with socket.create_connection((MQTT_IPC_HOST, MQTT_IPC_PORT), timeout=1.5) as sock:
+            sock.sendall(data)
+    except Exception:
+        pass
+
+
+_IPC_READY = True
+
+
+class _BridgeCommandHandler(socketserver.StreamRequestHandler):
+    def handle(self) -> None:
+        for line in self.rfile:
+            payload = line.decode("utf-8", errors="replace").strip()
+            if not payload:
+                continue
+            try:
+                message = json.loads(payload)
+            except json.JSONDecodeError:
+                _log(f"[BRIDGE] Invalid command payload: {payload!r}")
+                continue
+            command = message.get("command")
+            if command == "capture":
+                _log("[BRIDGE] Capture command received via IPC. Invoking MCU 'capture' function…")
+                try:
+                    bridge.call("capture")
+                except Exception as exc:
+                    _log(f"[BRIDGE] Error invoking 'capture': {exc}")
+            else:
+                _log(f"[BRIDGE] Unknown command received via IPC: {command!r}")
+
+
+def _start_command_server() -> socketserver.TCPServer:
+    server = socketserver.ThreadingTCPServer(
+        (BRIDGE_CMD_HOST, BRIDGE_CMD_PORT),
+        _BridgeCommandHandler,
+    )
+    server.daemon_threads = True
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    _log(f"[BRIDGE] Command server listening on {BRIDGE_CMD_HOST}:{BRIDGE_CMD_PORT}.")
+    return server
 
 
 def _user_loop() -> None:
-    _flush_log()
     time.sleep(0.1)
 
 
 def main() -> None:
     _log("[SYSTEM] UNO Q MQTT bridge starting…")
-    _start_mqtt()
+    command_server = _start_command_server()
 
-    App.run(user_loop=_user_loop)
+    try:
+        App.run(user_loop=_user_loop)
+    finally:
+        command_server.shutdown()
+        command_server.server_close()
 
 
 if __name__ == "__main__":
@@ -255,10 +218,4 @@ if __name__ == "__main__":
     except Exception as exc:
         _log(f"[ERROR] Unhandled exception: {exc}")
     finally:
-        try:
-            mqtt_client.loop_stop()
-            mqtt_client.disconnect()
-        except Exception:
-            pass
-        _flush_log()
         _log("[SYSTEM] Bridge script terminated.")

--- a/mqtt_server.py
+++ b/mqtt_server.py
@@ -1,0 +1,199 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+mqtt_server.py – MQTT process for the UNO Q measure rig
+
+Runs as a standalone process that connects to the MQTT broker, publishes
+measurement/log payloads received over a local IPC socket, and forwards
+capture commands back to the bridge process.
+"""
+
+import html
+import json
+import os
+import socket
+import socketserver
+import threading
+import time
+
+import paho.mqtt.client as mqtt
+
+
+# ─── Logging ───────────────────────────────────────────────
+
+def _sanitize_log(msg: str) -> str:
+    msg_str = str(msg)
+    escaped = html.escape(msg_str)
+    sanitized_chars = []
+    for ch in escaped:
+        if ch in "\n\r" or not ch.isprintable():
+            sanitized_chars.append(" ")
+        else:
+            sanitized_chars.append(ch)
+    return "".join(sanitized_chars)
+
+
+def _log(msg: str) -> None:
+    print(_sanitize_log(msg))
+
+
+# ─── Configuration ─────────────────────────────────────────
+
+def _get_int_env(name: str, default: int) -> int:
+    raw = os.getenv(name)
+    if raw is None:
+        return default
+    try:
+        return int(raw)
+    except (TypeError, ValueError):
+        _log(f"[CONFIG] Invalid value for {name}='{raw}', using default {default}.")
+        return default
+
+
+DEFAULT_MQTT_BROKER = "10.1.1.85"
+DEFAULT_MQTT_PORT = 1883
+
+MQTT_BROKER = os.getenv("MQTT_BROKER", DEFAULT_MQTT_BROKER)
+MQTT_PORT = _get_int_env("MQTT_PORT", DEFAULT_MQTT_PORT)
+MQTT_USER = os.getenv("MQTT_USER")
+MQTT_PASS = os.getenv("MQTT_PASS")
+
+MQTT_CMD_TOPIC = os.getenv("MQTT_CMD_TOPIC", "measure/cmd")
+MQTT_DATA_TOPIC = os.getenv("MQTT_DATA_TOPIC", "measure/data")
+MQTT_LOG_TOPIC = os.getenv("MQTT_LOG_TOPIC", "measure/log")
+MQTT_CLIENT_ID = os.getenv("MQTT_CLIENT_ID", "uno-q-bridge")
+
+MQTT_IPC_HOST = os.getenv("MQTT_IPC_HOST", "127.0.0.1")
+MQTT_IPC_PORT = _get_int_env("MQTT_IPC_PORT", 8765)
+BRIDGE_CMD_HOST = os.getenv("BRIDGE_CMD_HOST", "127.0.0.1")
+BRIDGE_CMD_PORT = _get_int_env("BRIDGE_CMD_PORT", 8766)
+
+mqtt_client = mqtt.Client(client_id=MQTT_CLIENT_ID, protocol=mqtt.MQTTv311)
+
+if MQTT_USER:
+    if MQTT_PASS is not None:
+        mqtt_client.username_pw_set(MQTT_USER, MQTT_PASS)
+    else:
+        mqtt_client.username_pw_set(MQTT_USER)
+
+
+# ─── MQTT Handling ─────────────────────────────────────────
+
+def _publish(topic: str, payload: str) -> None:
+    try:
+        mqtt_client.publish(topic, payload, qos=0, retain=False)
+    except Exception as exc:
+        _log(f"[MQTT] Failed to publish to {topic}: {exc}")
+
+
+def _send_bridge_command(command: str) -> None:
+    payload = json.dumps({"command": command}, separators=(",", ":")).encode("utf-8") + b"\n"
+    try:
+        with socket.create_connection((BRIDGE_CMD_HOST, BRIDGE_CMD_PORT), timeout=1.5) as sock:
+            sock.sendall(payload)
+        _log(f"[BRIDGE] Sent command '{command}' to bridge.")
+    except Exception as exc:
+        _log(f"[BRIDGE] Failed to send command '{command}' to bridge: {exc}")
+
+
+def _on_mqtt_connect(client, userdata, flags, rc, properties=None):
+    if rc == 0:
+        _log(f"[MQTT] Connected to {MQTT_BROKER}:{MQTT_PORT} as {MQTT_CLIENT_ID}.")
+        client.subscribe(MQTT_CMD_TOPIC)
+        _log(f"[MQTT] Subscribed to command topic '{MQTT_CMD_TOPIC}'.")
+    else:
+        _log(f"[MQTT] Connection failed with code {rc}.")
+
+
+def _on_mqtt_disconnect(client, userdata, rc, properties=None):
+    if rc != 0:
+        _log(f"[MQTT] Unexpected disconnect (rc={rc}). Will retry automatically.")
+
+
+def _on_mqtt_message(client, userdata, msg):
+    try:
+        payload = msg.payload.decode("utf-8", errors="replace").strip()
+    except Exception:
+        payload = repr(msg.payload)
+    _log(f"[MQTT] Received message on '{msg.topic}': {payload}")
+    if msg.topic != MQTT_CMD_TOPIC:
+        return
+    if payload.lower().startswith("cap"):
+        _send_bridge_command("capture")
+
+
+mqtt_client.on_connect = _on_mqtt_connect
+mqtt_client.on_disconnect = _on_mqtt_disconnect
+mqtt_client.on_message = _on_mqtt_message
+
+
+# ─── IPC Server ────────────────────────────────────────────
+
+class _BridgePayloadHandler(socketserver.StreamRequestHandler):
+    def handle(self) -> None:
+        for line in self.rfile:
+            payload = line.decode("utf-8", errors="replace").strip()
+            if not payload:
+                continue
+            try:
+                message = json.loads(payload)
+            except json.JSONDecodeError:
+                _log(f"[IPC] Invalid JSON payload: {payload!r}")
+                continue
+            msg_type = message.get("type")
+            if msg_type == "measurement":
+                payload_data = message.get("payload", {})
+                _publish(MQTT_DATA_TOPIC, json.dumps(payload_data))
+                _log("[MQTT] Published measurement payload.")
+            elif msg_type == "log":
+                log_message = message.get("message", "")
+                _publish(MQTT_LOG_TOPIC, str(log_message))
+            else:
+                _log(f"[IPC] Unknown payload type: {msg_type!r}")
+
+
+def _start_ipc_server() -> socketserver.TCPServer:
+    server = socketserver.ThreadingTCPServer(
+        (MQTT_IPC_HOST, MQTT_IPC_PORT),
+        _BridgePayloadHandler,
+    )
+    server.daemon_threads = True
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    _log(f"[IPC] Listening for bridge payloads on {MQTT_IPC_HOST}:{MQTT_IPC_PORT}.")
+    return server
+
+
+def _start_mqtt() -> None:
+    try:
+        mqtt_client.connect(MQTT_BROKER, MQTT_PORT, keepalive=60)
+        mqtt_client.loop_start()
+    except Exception as exc:
+        _log(f"[MQTT] Failed to connect to broker at {MQTT_BROKER}:{MQTT_PORT}: {exc}")
+
+
+# ─── Main ──────────────────────────────────────────────────
+
+def main() -> None:
+    _log("[SYSTEM] UNO Q MQTT server starting…")
+    _start_mqtt()
+    ipc_server = _start_ipc_server()
+
+    try:
+        while True:
+            time.sleep(1)
+    except KeyboardInterrupt:
+        _log("[SYSTEM] Shutdown requested by user (Ctrl-C).")
+    finally:
+        ipc_server.shutdown()
+        ipc_server.server_close()
+        try:
+            mqtt_client.loop_stop()
+            mqtt_client.disconnect()
+        except Exception:
+            pass
+        _log("[SYSTEM] MQTT server terminated.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
### Motivation
- Reduce responsibilities of the MCU bridge by moving MQTT broker communication into a dedicated process to improve isolation and reliability.
- Provide a simple IPC protocol so the bridge can forward measurements/logs and receive capture commands without embedding the MQTT client.

### Description
- Add `mqtt_server.py` which connects to the MQTT broker, subscribes to command topic, publishes measurement and log payloads, and forwards capture commands back to the bridge via a local TCP command socket.
- Update `bridge_mqtt.py` to compute measurements and forward JSON payloads to the MQTT process over a local IPC socket and to run a local command server that accepts `"capture"` RPCs from the MQTT process.
- Introduce IPC configuration environment variables `MQTT_IPC_HOST`, `MQTT_IPC_PORT`, `BRIDGE_CMD_HOST`, and `BRIDGE_CMD_PORT` and update `REF_*_CM` handling; remove the direct `paho-mqtt` dependency from the bridge.
- Document the new split and run/configuration instructions in `README.md` and add `mqtt_server.py` to the repository.

### Testing
- Ran `python3 -m py_compile bridge_mqtt.py mqtt_server.py` and both modules compiled without syntax errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_696b21726254833085c61fd84a94a451)