### PR TITLE
Coordinated shutdown and crash-exit for UNO Q worker threads

### DIFF
--- a/uno_q_app/python/bridge.py
+++ b/uno_q_app/python/bridge.py
@@ -199,13 +199,15 @@ def _user_loop() -> None:
     time.sleep(0.1)
 
 
-def main() -> None:
+def main(stop_event: Optional[threading.Event] = None) -> None:
     _log("[SYSTEM] UNO Q MQTT bridge starting…")
     command_server = _start_command_server()
 
     try:
         App.run(user_loop=_user_loop)
     finally:
+        if stop_event is not None:
+            stop_event.set()
         command_server.shutdown()
         command_server.server_close()
 

--- a/uno_q_app/python/dashboard.py
+++ b/uno_q_app/python/dashboard.py
@@ -27,12 +27,14 @@ import threading
 import time
 import traceback
 import html
+from typing import Optional
 # collections.deque provides efficient FIFO buffers
 from collections import deque
 
 # ─── Third‑party libraries ──────────────────────────
 import paho.mqtt.client as mqtt
 from flask import Flask, jsonify, make_response, render_template, request
+from werkzeug.serving import make_server
 import urllib.parse
 
 # ─── Configuration Constants ─────────────────────────
@@ -521,9 +523,13 @@ def manual_weight_api_route():
 
 # ─── Main Application Logic ────────────────────
 
-def run_application():
+def run_application(stop_event: Optional[threading.Event] = None):
     print("[SYSTEM] MeasurePi dashboard is starting up...")
+    if stop_event is None:
+        stop_event = threading.Event()
     flask_port = max(7000, int(os.getenv("FLASK_PORT", os.getenv("PORT", 7000))))
+    server = None
+    server_thread = None
     try:
         if MQTT_BROKER:
             try:
@@ -535,14 +541,24 @@ def run_application():
         else:
             print("[MQTT] MQTT_BROKER not configured. MQTT features disabled.")
         print(f"[SYSTEM] Starting Flask web server on http://0.0.0.0:{flask_port}...")
-        app.run(host="0.0.0.0", port=flask_port, threaded=True, debug=False)
+        server = make_server("0.0.0.0", flask_port, app, threaded=True)
+        server_thread = threading.Thread(target=server.serve_forever, name="dashboard-web")
+        server_thread.start()
+        while not stop_event.is_set():
+            time.sleep(0.5)
     except KeyboardInterrupt:
         print("\n[SYSTEM] Shutdown requested by user (KeyboardInterrupt).")
+        stop_event.set()
     except Exception as e:
         print(f"[ERROR] Unhandled exception in main application: {e}")
         traceback.print_exc()
     finally:
         print("[SYSTEM] Initiating shutdown sequence...")
+        stop_event.set()
+        if server is not None:
+            server.shutdown()
+        if server_thread is not None:
+            server_thread.join()
         try:
             if mqtt_client.is_connected():
                 print("[MQTT] Disconnecting MQTT client...")
@@ -554,6 +570,10 @@ def run_application():
         except Exception:
             pass
         print("[SYSTEM] MeasurePi dashboard has shut down.")
+
+
+def main(stop_event: Optional[threading.Event] = None):
+    run_application(stop_event)
 
 if __name__ == "__main__":
     run_application()

--- a/uno_q_app/python/main.py
+++ b/uno_q_app/python/main.py
@@ -21,8 +21,8 @@ def _start_background(name, target, stop_event):
         try:
             target(stop_event)
         except Exception:
-            print(f"[SYSTEM] Background worker {name} terminated unexpectedly.")
-            traceback.print_exc()
+            print(f"[SYSTEM] Background worker {name} terminated unexpectedly.", file=sys.stderr)
+            traceback.print_exc(file=sys.stderr)
             stop_event.set()
             os._exit(1)
 

--- a/uno_q_app/python/main.py
+++ b/uno_q_app/python/main.py
@@ -7,23 +7,40 @@ Starts the MQTT server, dashboard, and bridge in a single process so the
 Arduino App CLI can manage one service.
 """
 
+import os
 import threading
+import traceback
 
 import bridge
 import dashboard
 import mqtt
 
 
-def _start_background(name, target):
-    thread = threading.Thread(target=target, name=name, daemon=True)
+def _start_background(name, target, stop_event):
+    def _runner():
+        try:
+            target(stop_event)
+        except Exception:
+            print(f"[SYSTEM] Background worker {name} terminated unexpectedly.")
+            traceback.print_exc()
+            stop_event.set()
+            os._exit(1)
+
+    thread = threading.Thread(target=_runner, name=name)
     thread.start()
     return thread
 
 
 def main() -> None:
-    _start_background("mqtt", mqtt.main)
-    _start_background("dashboard", dashboard.main)
-    bridge.main()
+    stop_event = threading.Event()
+    mqtt_thread = _start_background("mqtt", mqtt.main, stop_event)
+    dashboard_thread = _start_background("dashboard", dashboard.main, stop_event)
+    try:
+        bridge.main(stop_event)
+    finally:
+        stop_event.set()
+        mqtt_thread.join()
+        dashboard_thread.join()
 
 
 if __name__ == "__main__":

--- a/uno_q_app/python/mqtt.py
+++ b/uno_q_app/python/mqtt.py
@@ -15,6 +15,7 @@ import socket
 import socketserver
 import threading
 import time
+from typing import Optional
 
 import paho.mqtt.client as mqtt
 
@@ -174,17 +175,21 @@ def _start_mqtt() -> None:
 
 # ─── Main ──────────────────────────────────────────────────
 
-def main() -> None:
+def main(stop_event: Optional[threading.Event] = None) -> None:
     _log("[SYSTEM] UNO Q MQTT server starting…")
+    if stop_event is None:
+        stop_event = threading.Event()
     _start_mqtt()
     ipc_server = _start_ipc_server()
 
     try:
-        while True:
+        while not stop_event.is_set():
             time.sleep(1)
     except KeyboardInterrupt:
         _log("[SYSTEM] Shutdown requested by user (Ctrl-C).")
+        stop_event.set()
     finally:
+        stop_event.set()
         ipc_server.shutdown()
         ipc_server.server_close()
         try:


### PR DESCRIPTION
### Motivation

- Prevent silent worker thread deaths by ensuring any unexpected exception in background workers causes the process to exit so supervising systems notice failures. 
- Provide a clean, coordinated shutdown so services stop in an orderly way instead of leaving daemon threads killed abruptly. 
- Make the entrypoint coordinate lifecycle across `mqtt`, `dashboard`, and `bridge` services with a shared stop event. 

### Description

- Wrap background workers in `main.py` with an internal `_runner` that catches exceptions, prints a traceback, sets the shared `stop_event`, and calls `os._exit(1)` to ensure immediate process termination on unexpected thread failure. 
- Run background workers as non-daemon threads and join them on exit from the bridge; introduced a shared `stop_event` passed to worker entrypoints (`mqtt.main`, `dashboard.main`, `bridge.main`).
- Make `mqtt.main` accept `stop_event` and stop its main loop when the event is set, and ensure the IPC server and MQTT client are shut down in the `finally` block. 
- Replace `app.run` in `dashboard` with a `werkzeug` `make_server` and run it in a thread so the server can be shut down programmatically; add `run_application(stop_event)` and `main(stop_event)` wrappers to respect the shared stop event and join the server thread during teardown. 
- Have `bridge.main` accept the optional `stop_event` and set it during shutdown so other services are informed when the bridge exits. 

Files changed: `uno_q_app/python/main.py`, `uno_q_app/python/mqtt.py`, `uno_q_app/python/dashboard.py`, `uno_q_app/python/bridge.py`.

### Testing

- Ran unit discovery with `python -m unittest discover -s uno_q_app/python` which completed successfully (`Ran 0 tests` and returned `OK`).
- Ran the linter with `python -m ruff check uno_q_app/python` and received `All checks passed!`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69758eeff42483308be373c48a097f77)