### PR TITLE
Make UNO Q app App Lab-friendly: expose dashboard port and bind IPC servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,8 @@ The application reads environment variables so you can adjust settings without e
 | `MQTT_IPC_PORT` | `8765` | Port for bridge → MQTT IPC (both processes). |
 | `BRIDGE_CMD_HOST` | `127.0.0.1` | Host for MQTT → bridge command IPC (both processes). |
 | `BRIDGE_CMD_PORT` | `8766` | Port for MQTT → bridge command IPC (both processes). |
+| `MQTT_IPC_BIND_HOST` | `0.0.0.0` | Bind host for the MQTT IPC server (mqtt.py). |
+| `BRIDGE_CMD_BIND_HOST` | `0.0.0.0` | Bind host for the bridge command server (bridge.py). |
 | `REF_LENGTH_CM` | `80.0` | Reference distance for the length sensor (bridge.py). |
 | `REF_HEIGHT_CM` | `89.0` | Reference distance for the height sensor (bridge.py). |
 | `REF_WIDTH_CM` | `70.0` | Reference distance for the width sensor (bridge.py). |

--- a/uno_q_app/app.yaml
+++ b/uno_q_app/app.yaml
@@ -6,6 +6,8 @@ services:
     command: python3
     args:
       - python/main.py
+    ports:
+      - 5000
 environment:
   MQTT_BROKER: "10.1.1.85"
   MQTT_PORT: "1883"
@@ -17,6 +19,8 @@ environment:
   MQTT_IPC_PORT: "8765"
   BRIDGE_CMD_HOST: "127.0.0.1"
   BRIDGE_CMD_PORT: "8766"
+  MQTT_IPC_BIND_HOST: "0.0.0.0"
+  BRIDGE_CMD_BIND_HOST: "0.0.0.0"
   REF_LENGTH_CM: "80.0"
   REF_HEIGHT_CM: "89.0"
   REF_WIDTH_CM: "70.0"

--- a/uno_q_app/python/bridge.py
+++ b/uno_q_app/python/bridge.py
@@ -84,6 +84,7 @@ def _get_float_env(name: str, default: float) -> float:
 MQTT_IPC_HOST = os.getenv("MQTT_IPC_HOST", "127.0.0.1")
 MQTT_IPC_PORT = _get_int_env("MQTT_IPC_PORT", 8765)
 BRIDGE_CMD_HOST = os.getenv("BRIDGE_CMD_HOST", "127.0.0.1")
+BRIDGE_CMD_BIND_HOST = os.getenv("BRIDGE_CMD_BIND_HOST", "0.0.0.0")
 BRIDGE_CMD_PORT = _get_int_env("BRIDGE_CMD_PORT", 8766)
 
 REF_LENGTH_CM = _get_float_env("REF_LENGTH_CM", 80.0)
@@ -185,13 +186,13 @@ class _BridgeCommandHandler(socketserver.StreamRequestHandler):
 
 def _start_command_server() -> socketserver.TCPServer:
     server = socketserver.ThreadingTCPServer(
-        (BRIDGE_CMD_HOST, BRIDGE_CMD_PORT),
+        (BRIDGE_CMD_BIND_HOST, BRIDGE_CMD_PORT),
         _BridgeCommandHandler,
     )
     server.daemon_threads = True
     thread = threading.Thread(target=server.serve_forever, daemon=True)
     thread.start()
-    _log(f"[BRIDGE] Command server listening on {BRIDGE_CMD_HOST}:{BRIDGE_CMD_PORT}.")
+    _log(f"[BRIDGE] Command server listening on {BRIDGE_CMD_BIND_HOST}:{BRIDGE_CMD_PORT}.")
     return server
 
 

--- a/uno_q_app/python/main.py
+++ b/uno_q_app/python/main.py
@@ -8,6 +8,7 @@ Arduino App CLI can manage one service.
 """
 
 import os
+import sys
 import threading
 import traceback
 

--- a/uno_q_app/python/mqtt.py
+++ b/uno_q_app/python/mqtt.py
@@ -65,6 +65,7 @@ MQTT_LOG_TOPIC = os.getenv("MQTT_LOG_TOPIC", "measure/log")
 MQTT_CLIENT_ID = os.getenv("MQTT_CLIENT_ID", "uno-q-bridge")
 
 MQTT_IPC_HOST = os.getenv("MQTT_IPC_HOST", "127.0.0.1")
+MQTT_IPC_BIND_HOST = os.getenv("MQTT_IPC_BIND_HOST", "0.0.0.0")
 MQTT_IPC_PORT = _get_int_env("MQTT_IPC_PORT", 8765)
 BRIDGE_CMD_HOST = os.getenv("BRIDGE_CMD_HOST", "127.0.0.1")
 BRIDGE_CMD_PORT = _get_int_env("BRIDGE_CMD_PORT", 8766)
@@ -155,13 +156,13 @@ class _BridgePayloadHandler(socketserver.StreamRequestHandler):
 
 def _start_ipc_server() -> socketserver.TCPServer:
     server = socketserver.ThreadingTCPServer(
-        (MQTT_IPC_HOST, MQTT_IPC_PORT),
+        (MQTT_IPC_BIND_HOST, MQTT_IPC_PORT),
         _BridgePayloadHandler,
     )
     server.daemon_threads = True
     thread = threading.Thread(target=server.serve_forever, daemon=True)
     thread.start()
-    _log(f"[IPC] Listening for bridge payloads on {MQTT_IPC_HOST}:{MQTT_IPC_PORT}.")
+    _log(f"[IPC] Listening for bridge payloads on {MQTT_IPC_BIND_HOST}:{MQTT_IPC_PORT}.")
     return server
 
 


### PR DESCRIPTION
### Motivation
- Allow the UNO Q app to run under Arduino App Lab by exposing the Flask dashboard port and making IPC endpoints bindable to the host network. 
- Keep existing behavior for clients (they continue to connect via loopback) while allowing the server sockets to be reachable from the App Lab environment. 
- Fix a missing `sys` import that caused error output paths to reference an undefined name.

### Description
- Expose the dashboard port in `uno_q_app/app.yaml` by adding `ports: - 5000` and add default env vars `MQTT_IPC_BIND_HOST` and `BRIDGE_CMD_BIND_HOST` set to `0.0.0.0`.
- Add `MQTT_IPC_BIND_HOST` in `uno_q_app/python/mqtt.py` and bind the MQTT IPC server to `(MQTT_IPC_BIND_HOST, MQTT_IPC_PORT)` while keeping `MQTT_IPC_HOST` for client connections and logging.
- Add `BRIDGE_CMD_BIND_HOST` in `uno_q_app/python/bridge.py` and bind the bridge command server to `(BRIDGE_CMD_BIND_HOST, BRIDGE_CMD_PORT)` while keeping `BRIDGE_CMD_HOST` for outbound connections.
- Add the missing `import sys` to `uno_q_app/python/main.py` and document the new bind-host env vars in `README.md`.

### Testing
- Ran `python -m unittest`, which completed successfully (0 tests run). 
- Ran the linter with `python -m ruff check uno_q_app/python`, which returned `All checks passed!`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_697a8ee2bad8833092ec66780d59ee70)