### PR TITLE
Handle RouterBridge loop compatibility

### DIFF
--- a/uno_q_app/sketch/sketch.ino
+++ b/uno_q_app/sketch/sketch.ino
@@ -376,6 +376,33 @@ static void bridgeCapture() {
   g_trigCapture = true;
 }
 
+template <int N>
+struct BridgePriority : BridgePriority<N - 1> {};
+
+template <>
+struct BridgePriority<0> {};
+
+template <typename T>
+auto bridgePump(T &bridge, BridgePriority<2>) -> decltype(bridge.loop(), void()) {
+  bridge.loop();
+}
+
+template <typename T>
+auto bridgePump(T &bridge, BridgePriority<1>) -> decltype(bridge.poll(), void()) {
+  bridge.poll();
+}
+
+template <typename T>
+auto bridgePump(T &bridge, BridgePriority<0>) -> decltype(bridge.update(), void()) {
+  bridge.update();
+}
+
+inline void bridgePump(...) {}
+
+static void bridgeLoop() {
+  bridgePump(Bridge, BridgePriority<2>{});
+}
+
 /* ------------------------------ Capture/publish -------------------------- */
 
 // Compute box dimension from raw distance and reference, clamp at >=0
@@ -625,7 +652,7 @@ void setup() {
 /* -------------------------------- Loop ------------------------------- */
 
 void loop() {
-  Bridge.loop();
+  bridgeLoop();
   laserLoop();
   if (!g_systemReady) {
     initSensorsStep();


### PR DESCRIPTION
### Motivation
- Prevent compilation errors when the installed RouterBridge library variant lacks a `loop()` member by gracefully supporting alternative APIs (`poll()` / `update()`).

### Description
- Add a small template-based compatibility wrapper (`bridgePump` + `bridgeLoop`) that preferentially calls `loop()`, then `poll()`, then `update()` if available, falling back to a no-op otherwise.
- Replace the direct `Bridge.loop()` call in `loop()` with `bridgeLoop()` so the sketch builds against multiple RouterBridge versions without changing runtime logic.
- Keep all existing Bridge usage (calls/provide/notify) unchanged.

### Testing
- Attempted to compile the sketch with `arduino-cli compile --fqbn arduino:zephyr:unoq uno_q_app/sketch`, which could not be executed because `arduino-cli` is not installed in this environment, so a full compile could not be verified automatically.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6980631f34ac833085a475ef59fe2e62)