### PR TITLE
Fix bridge pump overload detection for UNO Q sketch

### DIFF
--- a/uno_q_app/sketch/sketch.ino
+++ b/uno_q_app/sketch/sketch.ino
@@ -18,6 +18,7 @@
 #include <TFLI2C.h>
 #include <Adafruit_NeoPixel.h>
 #include <Arduino_RouterBridge.h>
+#include <utility>
 
 /* ------------------------------ Config ------------------------------ */
 
@@ -383,17 +384,20 @@ template <>
 struct BridgePriority<0> {};
 
 template <typename T>
-auto bridgePump(T &bridge, BridgePriority<2>) -> decltype(bridge.loop(), void()) {
+auto bridgePump(T &bridge, BridgePriority<2>)
+    -> decltype(std::declval<T &>().loop(), void()) {
   bridge.loop();
 }
 
 template <typename T>
-auto bridgePump(T &bridge, BridgePriority<1>) -> decltype(bridge.poll(), void()) {
+auto bridgePump(T &bridge, BridgePriority<1>)
+    -> decltype(std::declval<T &>().poll(), void()) {
   bridge.poll();
 }
 
 template <typename T>
-auto bridgePump(T &bridge, BridgePriority<0>) -> decltype(bridge.update(), void()) {
+auto bridgePump(T &bridge, BridgePriority<0>)
+    -> decltype(std::declval<T &>().update(), void()) {
   bridge.update();
 }
 


### PR DESCRIPTION
### Motivation
- Fix a compile-time SFINAE error where the `bridgePump` trailing return type referenced the parameter name `bridge` which is not in scope for the `decltype`, causing the sketch to fail to compile.

### Description
- Add `#include <utility>` and update the three `bridgePump` template trailing return types to use `std::declval<T&>().loop()/poll()/update()` instead of referring to the parameter `bridge` directly.

### Testing
- Ran `arduino-app-cli app build measurepi` to validate the sketch build, but the command failed because `arduino-app-cli` is not available in the current environment (build could not be completed here).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6982cd8f2d3c833081bf02d6a1099964)