### PR TITLE
Fix SFINAE detection for bridgePump overloads

### DIFF
--- a/uno_q_app/sketch/sketch.ino
+++ b/uno_q_app/sketch/sketch.ino
@@ -18,6 +18,7 @@
 #include <TFLI2C.h>
 #include <Adafruit_NeoPixel.h>
 #include <Arduino_RouterBridge.h>
+#include <utility>
 
 /* ------------------------------ Config ------------------------------ */
 
@@ -382,18 +383,18 @@ struct BridgePriority : BridgePriority<N - 1> {};
 template <>
 struct BridgePriority<0> {};
 
-template <typename T>
-auto bridgePump(T &bridge, BridgePriority<2>) -> decltype(bridge.loop(), void()) {
+template <typename T, typename = decltype(std::declval<T &>().loop())>
+void bridgePump(T &bridge, BridgePriority<2>) {
   bridge.loop();
 }
 
-template <typename T>
-auto bridgePump(T &bridge, BridgePriority<1>) -> decltype(bridge.poll(), void()) {
+template <typename T, typename = decltype(std::declval<T &>().poll())>
+void bridgePump(T &bridge, BridgePriority<1>) {
   bridge.poll();
 }
 
-template <typename T>
-auto bridgePump(T &bridge, BridgePriority<0>) -> decltype(bridge.update(), void()) {
+template <typename T, typename = decltype(std::declval<T &>().update())>
+void bridgePump(T &bridge, BridgePriority<0>) {
   bridge.update();
 }
 


### PR DESCRIPTION
### Motivation
- Fix a compile-time SFINAE/overload-detection issue when probing the Bridge object for `loop`/`poll`/`update` members that was caused by using a trailing-return `decltype` that referenced the parameter name out of scope. 
- Use a robust SFINAE technique that does not depend on naming a function parameter in the return type so overload selection works across toolchains.

### Description
- Added `#include <utility>` to enable `std::declval` for member detection. 
- Replaced the three `bridgePump` template overloads with default template-parameter SFINAE forms: `template<typename T, typename = decltype(std::declval<T&>().loop())> void bridgePump(T&, BridgePriority<2>)` (and similarly for `poll` and `update`).
- Kept the fallback `inline void bridgePump(...) {}` to handle types that lack those members. 
- Changes applied to `uno_q_app/sketch/sketch.ino` around the Bridge pumping helpers.

### Testing
- Attempted to run `arduino-app-cli app build measurepi` to validate the sketch build, but the command failed with `bash: command not found: arduino-app-cli`, so a compile verification could not be completed in this environment.
- No other automated tests or linters were executed here due to the unavailable build tool.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6982cd8f2d3c833081bf02d6a1099964)