### PR TITLE
Refresh README and AGENTS docs to align with UNO Q runtime behavior

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,13 @@ This guide applies to the entire `measurepi` repository unless a more specific `
 - Prefer clear, self-documenting code; add brief comments when logic is non-obvious.
 - Do **not** wrap import statements in `try/except` blocks.
 
+## Repository Layout
+
+- `uno_q_app/sketch/`: Arduino UNO Q microcontroller sketch (`sketch.ino`) and sketch metadata.
+- `uno_q_app/python/`: Linux-side services (`bridge.py`, `mqtt.py`, `dashboard.py`) and Flask template files.
+- `uno_q_app/app.yaml`: Arduino App manifest and default environment values.
+- `legacy/`: historical Raspberry Pi and UNO R4 assets kept for reference only.
+
 ## Python and JavaScript Style
 
 - Favor consistent formatting (Black-compatible Python, Prettier-friendly JavaScript).
@@ -19,10 +26,11 @@ This guide applies to the entire `measurepi` repository unless a more specific `
 ## Testing
 
 - Run relevant tests or linters when modifying executable code.
+- For documentation-only updates, tests are optional.
 - Record the commands and results in the change summary.
 - If no automated tests exist, perform a quick manual check and describe what you verified.
 
 ## Documentation
 
-- Update README or inline comments when behavior or usage changes.
-- Keep instructions current so future contributors can follow them easily.
+- Update README when behavior, defaults, ports, or environment variable names change.
+- Keep UNO Q deployment instructions aligned with `uno_q_app/app.yaml` and Python runtime behavior.

--- a/README.md
+++ b/README.md
@@ -62,11 +62,11 @@ arduino-app-cli app logs measurepi
 
 ## Configuration
 
-The application reads environment variables so you can adjust settings without editing code. Set them in the systemd unit or inline before starting the app.
+The application reads environment variables so you can adjust settings without editing code. Runtime defaults come from the Python modules, and UNO Q app deployments can override them via `uno_q_app/app.yaml`.
 
 | Variable | Default | Purpose |
 | --- | --- | --- |
-| `MQTT_BROKER` | `10.1.1.85` | MQTT broker hostname or IP (mqtt.py). |
+| `MQTT_BROKER` | `127.0.0.1` (runtime), `10.1.1.85` (`app.yaml`) | MQTT broker hostname or IP. |
 | `MQTT_PORT` | `1883` | MQTT broker port (mqtt.py). |
 | `MQTT_USER` | (unset) | MQTT username (mqtt.py). |
 | `MQTT_PASS` | (unset) | MQTT password (mqtt.py). |
@@ -83,8 +83,11 @@ The application reads environment variables so you can adjust settings without e
 | `REF_LENGTH_CM` | `80.0` | Reference distance for the length sensor (bridge.py). |
 | `REF_HEIGHT_CM` | `89.0` | Reference distance for the height sensor (bridge.py). |
 | `REF_WIDTH_CM` | `70.0` | Reference distance for the width sensor (bridge.py). |
-| `DASHBOARD_PORT` | `5000` | Flask dashboard port. |
-| `ALLOWED_ORIGINS` | `*` | Comma-separated list of allowed dashboard origins. |
+| `FLASK_PORT` | `7000` minimum in `dashboard.py`; `5000` in `app.yaml` | Dashboard HTTP port (effective value is clamped to at least 7000 by code). |
+| `PORT` | `7000` fallback | Alternate dashboard port variable used if `FLASK_PORT` is unset. |
+| `CORS_ALLOWED_ORIGINS` | `https://nzc.gosweetspot.com` | Comma-separated list of allowed origins for CORS/CSRF checks. |
+
+> Note: `DASHBOARD_PORT` and `ALLOWED_ORIGINS` are present in `app.yaml`, but current Python code uses `FLASK_PORT`/`PORT` and `CORS_ALLOWED_ORIGINS`.
 
 Example:
 ```bash
@@ -127,13 +130,19 @@ Older Raspberry Pi and UNO R4 WiFi assets have been moved into the `legacy/` dir
 ## Developing and Testing Locally
 
 You can run the Python dashboard and MQTT bridge on a regular computer for testing. The
-bridge, MQTT server, and dashboard now run as separate processes, so start each script
-in its own terminal session:
+bridge, MQTT server, and dashboard are standalone modules, so you can either run them
+individually (three terminals):
 
 ```bash
 python3 uno_q_app/python/bridge.py
 python3 uno_q_app/python/mqtt.py
 python3 uno_q_app/python/dashboard.py
+```
+
+Or run the production-style supervisor (`main.py`), which starts all three services:
+
+```bash
+python3 uno_q_app/python/main.py
 ```
 
 Set the environment variables above to match your test environment. When running off-board, you may need to stub the Router Bridge calls.


### PR DESCRIPTION
### Motivation
- Clarify runtime configuration and variable names after observing divergence between `uno_q_app/app.yaml` defaults and what the Python services actually use at runtime. 
- Make local development and deployment instructions explicit so contributors know how to run services individually or under the production supervisor. 
- Provide a concise repository-level agent guide so expectations for testing, formatting, and documentation upkeep are clear. 

### Description
- Updated `README.md` to document that runtime defaults come from the Python modules and to reconcile `MQTT_BROKER` defaults, noting the difference between runtime (`127.0.0.1`) and `app.yaml` (`10.1.1.85`).
- Replaced legacy `DASHBOARD_PORT`/`ALLOWED_ORIGINS` rows with the actual runtime variables used by the code: `FLASK_PORT`/`PORT` and `CORS_ALLOWED_ORIGINS`, and added a note about the `app.yaml` vs runtime mismatch.
- Expanded local run instructions to show both running the three services individually and running the supervisor via `python3 uno_q_app/python/main.py`.
- Renamed `Agents.MD` to `AGENTS.md` and refreshed its contents to include a brief repository layout, testing guidance, and documentation expectations.

### Testing
- Validated the documentation changes by listing and inspecting files with `rg --files` and viewing contents with `nl -ba README.md` and `cat AGENTS.md`, and these checks succeeded. 
- Per repository policy, no code paths were modified so unit tests and linters were intentionally not run for this documentation-only change. 
- Confirmed that the updated README reflects the actual variables and behavior observed in `uno_q_app/python/{bridge,mqtt,dashboard}.py` via targeted `sed -n` and `rg` lookups, and those inspections succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69978016d2ec8330801b76b20f863c3b)